### PR TITLE
Fix syntax error in service_request_hooks

### DIFF
--- a/ferum_customs/api.py
+++ b/ferum_customs/api.py
@@ -1,5 +1,5 @@
-
 from typing import Optional
+
 import frappe
 from frappe import _, whitelist
 from frappe.exceptions import PermissionError

--- a/ferum_customs/custom_logic/payroll_entry_hooks.py
+++ b/ferum_customs/custom_logic/payroll_entry_hooks.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 	# from ..doctype.service_report.service_report import ServiceReport # Если используется в расчетах
 
 
-
 def validate(doc: PayrollEntryCustom, method: str | None = None) -> None:
 	"""
 	Проверяет корректность дат периода. Дата окончания не может быть раньше даты начала.
@@ -39,7 +38,6 @@ def validate(doc: PayrollEntryCustom, method: str | None = None) -> None:
 	# Сюда можно добавить другие проверки для PayrollEntryCustom.
 	# if not doc.get("employee"):
 	#     frappe.throw(_("Не выбран сотрудник для расчета зарплаты."))
-
 
 
 def before_save(doc: PayrollEntryCustom, method: str | None = None) -> None:
@@ -79,7 +77,6 @@ def before_save(doc: PayrollEntryCustom, method: str | None = None) -> None:
 
 	if doc.get("total_payable") is None:
 		doc.total_payable = 0.0
-
 
 	if isinstance(doc.get("total_payable"), float | int):
 		doc.total_payable = round(doc.total_payable, 2)

--- a/ferum_customs/custom_logic/service_object_hooks.py
+++ b/ferum_customs/custom_logic/service_object_hooks.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 	# ServiceObject = Document
 
 
-
 def validate(doc: ServiceObject, method: str | None = None) -> None:
 	"""
 	Проверяет уникальность серийного номера объекта обслуживания.

--- a/ferum_customs/custom_logic/service_report_hooks.py
+++ b/ferum_customs/custom_logic/service_report_hooks.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 # --------------------------------------------------------------------------- #
 
 
-
 def validate(doc: ServiceReport, method: str | None = None) -> None:
 	"""
 	Проверяет, что отчёт ссылается на существующую заявку со статусом «Выполнена».
@@ -70,9 +69,7 @@ def validate(doc: ServiceReport, method: str | None = None) -> None:
 		)
 
 
-
 def on_submit(doc: ServiceReport, method: str | None = None) -> None:
-
 	"""
 	После отправки (submit) отчёта обновляет связанную service_request.
 
@@ -92,7 +89,6 @@ def on_submit(doc: ServiceReport, method: str | None = None) -> None:
 
 	try:
 		req: ServiceRequest = frappe.get_doc("Service Request", doc.service_request)
-
 
 		req.set(FIELD_CUSTOM_LINKED_REPORT, doc.name)
 

--- a/ferum_customs/custom_logic/service_request_hooks.py
+++ b/ferum_customs/custom_logic/service_request_hooks.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-
 import frappe
 from frappe import _
 from frappe.utils import get_link_to_form, now
@@ -62,14 +61,12 @@ def validate(doc: ServiceRequest, method: str | None = None) -> None:
 
 
 def on_update_after_submit(doc: ServiceRequest, method: str | None = None) -> None:
-
 	"""Вызывается после обновления отправленного документа."""
 	if doc.status == STATUS_ZAKRYTA:
 		_notify_project_manager(doc)
 
 
 def prevent_deletion_with_links(doc: ServiceRequest, method: str | None = None) -> None:
-
 	"""Запрещает удаление заявки, если на нее есть ссылки."""
 	if linked_report := frappe.db.exists("Service Report", {"service_request": doc.name}):
 		frappe.throw(
@@ -86,14 +83,12 @@ def prevent_deletion_with_links(doc: ServiceRequest, method: str | None = None) 
 
 @frappe.whitelist()
 def get_engineers_for_object(service_object_name: str) -> list[str]:
-
 	"""Возвращает список инженеров, назначенных на объект обслуживания."""
 	if not service_object_name:
 		return []
 
 	try:
 		so_doc: FrappeDocument = frappe.get_doc("Service Object", service_object_name)
-appeDocument" = frappe.get_doc("Service Object", service_object_name)
 		engineers_table = so_doc.get("assigned_engineers") or []
 		return list({entry.get("engineer") for entry in engineers_table if entry.get("engineer")})
 	except frappe.DoesNotExistError:

--- a/ferum_customs/ferum_customs/doctype/service_project/service_project.py
+++ b/ferum_customs/ferum_customs/doctype/service_project/service_project.py
@@ -81,7 +81,6 @@ class ServiceProject(Document):  # Имя класса в CamelCase
 			field_value = self.get(fieldname)
 			if field_value and not isinstance(field_value, str):
 				if isinstance(field_value, datetime.datetime | datetime.date):
-
 					try:
 						setattr(self, fieldname, field_value.isoformat())
 					except Exception as e:

--- a/ferum_customs/ferum_customs/doctype/service_report/service_report.py
+++ b/ferum_customs/ferum_customs/doctype/service_report/service_report.py
@@ -43,7 +43,6 @@ class ServiceReport(Document):
 		if posting_date_val:
 			if not isinstance(posting_date_val, str):
 				if isinstance(posting_date_val, datetime.datetime | datetime.date):
-
 					self.posting_date = posting_date_val.isoformat()
 		else:
 			if self.is_new() and self.meta.get_field("posting_date").reqd:
@@ -98,7 +97,6 @@ class ServiceReport(Document):
 		total_pay: float = 0.0
 
 		work_items_table: list[Document] = self.get("work_items", [])
-
 
 		for item in work_items_table:
 			try:


### PR DESCRIPTION
## Summary
- fix broken indentation and stray line in `service_request_hooks.py`
- run ruff autoformatting across hooks

## Testing
- `pytest -q`
- `pre-commit run --files $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68558f481d648328b1b697c4df2b0366