### PR TITLE
Adjust permissions and doc perms

### DIFF
--- a/ferum_customs/ferum_customs/doctype/service_object/service_object.json
+++ b/ferum_customs/ferum_customs/doctype/service_object/service_object.json
@@ -43,6 +43,8 @@
     }
   ],
   "permissions": [
+    { "role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1, "submit": 1, "cancel": 1, "amend": 1 },
+    { "role": "Administrator", "read": 1, "write": 1, "create": 1, "delete": 1, "submit": 1, "cancel": 1, "amend": 1 },
     { "role": "Проектный менеджер", "read": 1, "write": 1, "create": 1, "delete": 1 },
     { "role": "Инженер", "read": 1 }
   ]

--- a/ferum_customs/ferum_customs/doctype/service_project/service_project.json
+++ b/ferum_customs/ferum_customs/doctype/service_project/service_project.json
@@ -25,6 +25,10 @@
     },
     { "fieldname": "start_date", "label": "Дата начала", "fieldtype": "Date" },
     { "fieldname": "end_date", "label": "Дата окончания", "fieldtype": "Date" }
+  ],
+  "permissions": [
+    { "role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1, "submit": 1, "cancel": 1, "amend": 1 },
+    { "role": "Administrator", "read": 1, "write": 1, "create": 1, "delete": 1, "submit": 1, "cancel": 1, "amend": 1 }
   ]
 }
 ]

--- a/ferum_customs/ferum_customs/doctype/service_report/service_report.json
+++ b/ferum_customs/ferum_customs/doctype/service_report/service_report.json
@@ -81,6 +81,26 @@
     ],
     "permissions": [
         {
+            "role": "System Manager",
+            "read": 1,
+            "write": 1,
+            "create": 1,
+            "delete": 1,
+            "submit": 1,
+            "cancel": 1,
+            "amend": 1
+        },
+        {
+            "role": "Administrator",
+            "read": 1,
+            "write": 1,
+            "create": 1,
+            "delete": 1,
+            "submit": 1,
+            "cancel": 1,
+            "amend": 1
+        },
+        {
             "role": "Проектный менеджер",
             "read": 1,
             "write": 1,

--- a/ferum_customs/fixtures/custom_docperm.json
+++ b/ferum_customs/fixtures/custom_docperm.json
@@ -59,7 +59,7 @@
     "share": 0,
     "print": 1,
     "email": 1,
-    "if_owner": 0,
+    "if_owner": 1,
     "match": ""
   },
   {
@@ -80,7 +80,7 @@
     "share": 0,
     "print": 1,
     "email": 1,
-    "if_owner": 0,
+    "if_owner": 1,
     "match": ""
   }
 ]


### PR DESCRIPTION
## Summary
- tweak owner-based read permissions for customer roles
- ensure System Manager and Administrator have full access to new DocTypes
- allow Engineer access to Service Report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590033b7708328ba7b8ba64a8ff310