### PR TITLE
Add tests for portal menu roles

### DIFF
--- a/tests/unit/test_portal_menu_roles.py
+++ b/tests/unit/test_portal_menu_roles.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+FIXTURE_PATH = Path("ferum_customs/fixtures")
+
+
+def load_fixture(name: str):
+	return json.loads((FIXTURE_PATH / name).read_text())
+
+
+def test_portal_menu_item_role_customer():
+	items = load_fixture("portal_menu_item.json")
+	assert items, "portal_menu_item.json is empty"
+	for item in items:
+		assert item["role"] == "Customer"
+		assert item["role"] != "Guest"
+
+
+def test_no_guest_in_custom_docperm():
+	docperms = load_fixture("custom_docperm.json")
+	roles = {perm["role"] for perm in docperms}
+	assert "Guest" not in roles


### PR DESCRIPTION
## Summary
- ensure the portal menu item is restricted to the Customer role
- verify that no Guest permissions appear in custom_docperm

## Testing
- `pre-commit run --files tests/unit/test_portal_menu_roles.py ferum_customs/fixtures/portal_menu_item.json ferum_customs/fixtures/custom_docperm.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590165993c832880f9a65524520e35