### PR TITLE
Enable Track Changes for child doctypes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,7 @@
 All security vulnerabilities should be reported via email to [support@ferum.ru](mailto:support@ferum.ru). We will respond as soon as possible.
 
 Please do not disclose security issues publicly until they have been investigated and patched.
+
+## Logging
+
+All DocTypes in the application enable the **Track Changes** option. This records every modification in the standard `Version` DocType. Significant security events are also written to the built‑in **Error Log** so that administrators can review them.

--- a/ferum_customs/ferum_customs/doctype/assigned_engineer_item/assigned_engineer_item.json
+++ b/ferum_customs/ferum_customs/doctype/assigned_engineer_item/assigned_engineer_item.json
@@ -3,6 +3,7 @@
     "name": "Assigned Engineer Item",
     "module": "Ferum Customs",
     "istable": 1,
+    "track_changes": 1,
     "fields": [
         {
             "fieldname": "engineer",

--- a/ferum_customs/ferum_customs/doctype/custom_attachment/custom_attachment.json
+++ b/ferum_customs/ferum_customs/doctype/custom_attachment/custom_attachment.json
@@ -2,6 +2,7 @@
     "doctype": "DocType",
     "name": "Custom Attachment",
     "module": "Ferum Customs",
+    "track_changes": 1,
     "fields": [
         {
             "fieldname": "attachment_type",

--- a/ferum_customs/ferum_customs/doctype/payroll_entry_custom/payroll_entry_custom.json
+++ b/ferum_customs/ferum_customs/doctype/payroll_entry_custom/payroll_entry_custom.json
@@ -2,6 +2,7 @@
     "doctype": "DocType",
     "name": "Payroll Entry Custom",
     "module": "Ferum Customs",
+    "track_changes": 1,
     "fields": [
         {
             "fieldname": "total_payable",

--- a/ferum_customs/ferum_customs/doctype/service_report_document_item/service_report_document_item.json
+++ b/ferum_customs/ferum_customs/doctype/service_report_document_item/service_report_document_item.json
@@ -3,6 +3,7 @@
     "name": "Service Report Document Item",
     "module": "Ferum Customs",
     "istable": 1,
+    "track_changes": 1,
     "fields": [
         {
             "fieldname": "document_title",


### PR DESCRIPTION
## Summary
- enable Track Changes on remaining DocTypes
- document logging in SECURITY.md

## Testing
- `pre-commit run --files SECURITY.md ferum_customs/ferum_customs/doctype/assigned_engineer_item/assigned_engineer_item.json ferum_customs/ferum_customs/doctype/custom_attachment/custom_attachment.json ferum_customs/ferum_customs/doctype/payroll_entry_custom/payroll_entry_custom.json ferum_customs/ferum_customs/doctype/service_report_document_item/service_report_document_item.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590245e7c0832883f1a8aeeaa3b03b