### PR TITLE
Fix report fixtures with required fields

### DIFF
--- a/ferum_customs/ferum_customs/report/engineer_workload/engineer_workload.json
+++ b/ferum_customs/ferum_customs/report/engineer_workload/engineer_workload.json
@@ -1,10 +1,14 @@
 {
- "add_total_row": 0,
- "is_standard": "Yes",
- "ref_doctype": "service_request",
- "report_name": "Engineer Workload",
- "report_type": "Script Report",
- "roles": [
-  {"role": "Проектный менеджер"}
- ]
+  "doctype": "Report",
+  "name": "Engineer Workload",
+  "report_name": "Engineer Workload",
+  "ref_doctype": "service_request",
+  "report_type": "Script Report",
+  "is_standard": "Yes",
+  "add_total_row": 0,
+  "roles": [
+    {
+      "role": "Проектный менеджер"
+    }
+  ]
 }

--- a/ferum_customs/ferum_customs/report/service_request_overview/service_request_overview.json
+++ b/ferum_customs/ferum_customs/report/service_request_overview/service_request_overview.json
@@ -1,10 +1,14 @@
 {
- "add_total_row": 0,
- "is_standard": "Yes",
- "ref_doctype": "service_request",
- "report_name": "Service Request Overview",
- "report_type": "Script Report",
- "roles": [
-  {"role": "Проектный менеджер"}
- ]
+  "doctype": "Report",
+  "name": "Service Request Overview",
+  "report_name": "Service Request Overview",
+  "ref_doctype": "service_request",
+  "report_type": "Script Report",
+  "is_standard": "Yes",
+  "add_total_row": 0,
+  "roles": [
+    {
+      "role": "Проектный менеджер"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add missing `doctype` and `name` keys to report fixtures

## Testing
- `pytest -q`
- `bench --site test_site install-app ferum_customs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590a835a4c832891ead1af1825a7f4