### PR TITLE
Setup ERPNext in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,22 @@ jobs:
           bench get-app ferum_customs $GITHUB_WORKSPACE
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
+        env:
+          CI: 'Yes'
+
+      - name: Get & install ERPNext
+        working-directory: /home/runner/frappe-bench
+        run: |
+          # Скачиваем ERPNext той же версии, что и Frappe (пример: v15)
+          bench get-app erpnext --branch version-15 https://github.com/frappe/erpnext
+          # Устанавливаем ERPNext в сайт
+          bench --site test_site install-app erpnext
+        env:
+          CI: 'Yes'
+
+      - name: Install ferum_customs
+        working-directory: /home/runner/frappe-bench
+        run: |
           bench --site test_site install-app ferum_customs
           bench build
         env:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,7 @@ This document explains how to install the `ferum_customs` app in your Frappe/ERP
 
 ## Requirements
 
+- Требуется **Frappe + ERPNext**.
 - Tested with **Frappe/ERPNext 15.0**. Older versions are not officially supported.
 - A working [bench](https://github.com/frappe/bench) setup.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You can install this app using the [bench](https://github.com/frappe/bench) CLI:
 ```bash
 cd $PATH_TO_YOUR_BENCH
 bench get-app $URL_OF_THIS_REPO --branch main
+bench get-app erpnext --branch version-15 https://github.com/frappe/erpnext
 bench install-app ferum_customs
 # Run all bench commands from within your bench directory so that the correct
 # Python environment is used


### PR DESCRIPTION
## Summary
- install ERPNext before app in CI workflow
- document ERPNext fetch step in install docs
- clarify that Frappe + ERPNext are required

## Testing
- `pytest -q`
- `pre-commit run --files README.md INSTALL.md .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6859185cfc548328bf1ea46cde86f8c2