### PR TITLE
Add Docker-based dev stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,23 +68,28 @@ jobs:
           key: ${{ runner.os }}-buildkit-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildkit-
 
-      - name: Upgrade Docker Compose
-        run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/v2.23.3/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          docker compose version
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push frappe layer cache
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.frappe
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and start Frappe Stack
-        run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d --build
+        run: DOCKER_BUILDKIT=1 docker compose up -d --build
 
-      - name: Create Frappe test site
-        run: |
-          docker compose exec -T frappe bench new-site $SITE_NAME \
-            --admin-password $ADMIN_PASSWORD --no-mariadb-socket \
-            --install-app erpnext --install-app ferum_customs
-        env:
-          SITE_NAME: test_site
-          ADMIN_PASSWORD: admin
+      - name: Verify site exists
+        run: docker compose exec -T frappe bench --site $SITE_NAME --force reload-doc
 
       - name: Wait for site to be ready
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Guidelines
+
+CI uses a Docker-based stack defined in `docker-compose.yml`. Workflows start containers using this stack to run tests.

--- a/Dockerfile.frappe
+++ b/Dockerfile.frappe
@@ -1,0 +1,14 @@
+FROM frappe/bench:latest
+
+# Install Python 3.11 and dev dependencies if needed
+ARG PYTHON_VERSION
+RUN /usr/local/bin/pyenv install -s ${PYTHON_VERSION} \
+ && pyenv global ${PYTHON_VERSION}
+
+# Clone applications
+WORKDIR /workspace
+RUN bench get-app --branch version-16 erpnext https://github.com/frappe/erpnext
+
+# ferum_customs -> copy local app (container build from repo root)
+COPY . /workspace/apps/ferum_customs
+RUN bench setup requirements --yes

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ This document explains how to install the `ferum_customs` app in your Frappe/ERP
 - ERPNext branch must match your Frappe version (e.g. `version-15`).
 - A working [bench](https://github.com/frappe/bench) setup.
 
-## Steps
+## Bare-metal
 
 1. Clone this repository inside your bench directory:
    ```bash
@@ -23,6 +23,13 @@ This document explains how to install the `ferum_customs` app in your Frappe/ERP
    ```bash
    bench build && bench restart
    ```
+## Docker
+
+Run the stack with:
+```bash
+docker compose up -d --build
+```
+
 
 If you use Docker images, add `ferum_customs` to `apps.txt` (or `apps.json`) and rebuild the image before running the `install-app` command.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ bench install-app ferum_customs
 # Run all bench commands from within your bench directory so that the correct
 # Python environment is used
 ```
+### Запуск в Docker
+
+Run the stack with:
+```bash
+docker compose up -d
+```
+
 
 ### Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+version: "3.9"
+
+services:
+  mariadb:
+    image: mariadb:10.6
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - dbdata:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-proot"]
+      interval: 10s
+      retries: 5
+
+  redis:
+    image: redis:6
+    volumes:
+      - redisdata:/data
+
+  frappe:
+    build:
+      context: .
+      dockerfile: Dockerfile.frappe
+      args:
+        - PYTHON_VERSION=3.11
+    depends_on:
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    ports:
+      - "8000:8000"
+    environment:
+      SITE_NAME: ${SITE_NAME:-test_site}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
+      DB_ROOT_PASSWORD: root
+    volumes:
+      - ./sites:/workspace/sites
+    command: >
+      bash -c "
+        bench new-site $SITE_NAME
+          --admin-password $ADMIN_PASSWORD
+          --mariadb-root-password $DB_ROOT_PASSWORD
+          --no-mariadb-socket &&
+        bench --site $SITE_NAME install-app erpnext &&
+        bench --site $SITE_NAME install-app ferum_customs &&
+        bench start
+      "
+
+volumes:
+  dbdata:
+  redisdata:


### PR DESCRIPTION
## Summary
- add Docker compose stack and image build
- update README and install guide
- document Docker stack usage in AGENTS
- tweak CI workflow to build using Docker and cache layers

## Testing
- `pre-commit run --files README.md INSTALL.md AGENTS.md docker-compose.yml Dockerfile.frappe .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591fef82108328bc95bf23dfb5612b