### PR TITLE
Remove buildx cache step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push frappe layer cache
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile.frappe
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Build and start Frappe Stack
         run: DOCKER_BUILDKIT=1 docker compose up -d --build


### PR DESCRIPTION
## Summary
- remove buildx cache step from GitHub Actions workflow

## Testing
- `pip install -r requirements-dev.txt`
- `bench --site test_site run-tests --app ferum_customs --tests-path tests/unit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592201d1808328a3c72e4c3b87f880