### PR TITLE
Remove pyenv usage from build

### DIFF
--- a/Dockerfile.frappe
+++ b/Dockerfile.frappe
@@ -1,9 +1,11 @@
 FROM frappe/bench:latest
 
 # Install Python 3.11 and dev dependencies if needed
-ARG PYTHON_VERSION
-RUN /usr/local/bin/pyenv install -s ${PYTHON_VERSION} \
- && pyenv global ${PYTHON_VERSION}
+ARG PYTHON_VERSION=3.11
+# The base image already includes Python 3.11 so
+# we don't need to install it via pyenv.
+# RUN /usr/local/bin/pyenv install -s ${PYTHON_VERSION} \
+#  && pyenv global ${PYTHON_VERSION}
 
 # Clone applications
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- default `PYTHON_VERSION` to 3.11
- drop `pyenv` commands from Dockerfile

## Testing
- `pip install -r requirements-dev.txt`
- `bench --site test_site run-tests --app ferum_customs --tests-path tests/unit` *(fails: bench: command not found)*
- `docker compose build frappe` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859262c3e688328a8c1fa703607a2fb