### PR TITLE
Fix GitHub Actions MariaDB client install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,11 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install MariaDB Client
-        run: sudo apt-get install mariadb-client-10.6
+        env:
+          MARIADB_CLIENT_PKG: mariadb-client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y $MARIADB_CLIENT_PKG
 
       - name: Setup
         run: |


### PR DESCRIPTION
## Summary
- install `mariadb-client` in CI instead of version-specific package

## Testing
- `pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_685927b522d88328ba8517446587413a