### PR TITLE
Configure bench user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,15 @@ jobs:
         run: |
           bench get-app ferum_customs $GITHUB_WORKSPACE
           bench setup requirements --dev
-          bench pip install pytest pytest-cov
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app ferum_customs
           bench build
         env:
           CI: 'Yes'
+
+      - name: Install test deps
+        working-directory: /home/frappe/frappe-bench
+        run: bench pip install pytest pytest-cov
 
       - name: Run Tests
         working-directory: /home/runner/frappe-bench

--- a/Dockerfile.frappe
+++ b/Dockerfile.frappe
@@ -7,10 +7,17 @@ ARG PYTHON_VERSION=3.11
 # RUN /usr/local/bin/pyenv install -s ${PYTHON_VERSION} \
 #  && pyenv global ${PYTHON_VERSION}
 
+# The base image already contains a non-root user `frappe` (uid 1000)
+USER frappe
+WORKDIR /home/frappe
+
+# Initialize bench as the frappe user
+RUN bench init --skip-assets frappe-bench --python $(which python)
+WORKDIR /home/frappe/frappe-bench
+
 # Clone applications
-WORKDIR /workspace
 RUN bench get-app --branch version-16 erpnext https://github.com/frappe/erpnext
 
-# ferum_customs -> copy local app (container build from repo root)
-COPY . /workspace/apps/ferum_customs
+# Add the local app during build
+COPY --chown=frappe:frappe . /home/frappe/frappe-bench/apps/ferum_customs
 RUN bench setup requirements --yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       dockerfile: Dockerfile.frappe
       args:
         - PYTHON_VERSION=3.11
+    user: "1000:1000"
     depends_on:
       mariadb:
         condition: service_healthy
@@ -38,7 +39,7 @@ services:
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
       DB_ROOT_PASSWORD: root
     volumes:
-      - ./sites:/workspace/sites
+      - ./sites:/home/frappe/frappe-bench/sites
     command: >
       bash -c "
         bench new-site $SITE_NAME

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 
 [project.optional-dependencies.test]
 pytest = ">=8,<9"
+pytest-cov = "*"
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]


### PR DESCRIPTION
## Summary
- set up bench initialization as frappe user in Dockerfile
- map `./sites` volume to bench directory and use uid 1000 in compose file
- separate CI step to install test packages
- declare `pytest-cov` optional dependency

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592ae4a93c8328a83052375e57e28a