### PR TITLE
Fix optional dependencies lists and lint validation

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,6 +23,17 @@ jobs:
         with:
           python-version: '3.10'
           cache: pip
+      - name: Validate pyproject
+        run: |
+          python - <<'PY'
+          import tomllib, pathlib, sys
+          path = pathlib.Path("pyproject.toml")
+          d = tomllib.loads(path.read_text())
+          if "optional-dependencies" in d.get("project", {}):
+              for k, v in d["project"]["optional-dependencies"].items():
+                  if not isinstance(v, list):
+                      sys.exit(f"[{k}] must be a list, got {type(v).__name__}")
+          PY
       - uses: pre-commit/action@v3.0.0
 
       - name: Download Semgrep rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,16 @@ dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
 ]
 
-[project.optional-dependencies.test]
-pytest = ">=8,<9"
-pytest-cov = "*"
+[project.optional-dependencies]
+test = [
+    "pytest>=8,<9",
+    "pytest-cov>=6,<7",
+]
+dev = [
+    "ruff",
+    "pre-commit",
+]
+
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]


### PR DESCRIPTION
## Summary
- fix format for optional dependencies in `pyproject.toml`
- ensure CI validates that optional dependencies are lists

## Testing
- `pip install -e .[test]`
- `python -c "import pytest, pytest_cov; print('OK')"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592cc68104832885421a414466593a