### PR TITLE
Add ERPNext to CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,13 @@ jobs:
         working-directory: ${{ env.BENCH_PATH }}
         run: |
           bench get-app ferum_customs $GITHUB_WORKSPACE
+          bench get-app --branch version-16 erpnext https://github.com/frappe/erpnext
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
+          bench --site test_site install-app erpnext
           bench --site test_site install-app ferum_customs
           bench build
+          bench --site test_site list-apps
         env:
           CI: 'Yes'
 


### PR DESCRIPTION
## Summary
- ensure ERPNext is installed in the CI workflow
- verify installed apps

## Testing
- `pip install -r requirements-dev.txt`
- `bench --site test_site run-tests --app ferum_customs --tests-path tests/unit` *(fails: bench not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_685931493db883289a80da2f29ce8b2d