### PR TITLE
Fix ServiceReportWorkItem DocType fixture

### DIFF
--- a/ferum_customs/ferum_customs/doctype/service_report_work_item/service_report_work_item.json
+++ b/ferum_customs/ferum_customs/doctype/service_report_work_item/service_report_work_item.json
@@ -1,6 +1,6 @@
 {
     "doctype": "DocType",
-    "name": "Service Report Work Item", 
+    "name": "ServiceReportWorkItem",
     "module": "Ferum Customs",
     "istable": 1,
     "engine": "InnoDB",

--- a/ferum_customs/hooks.py
+++ b/ferum_customs/hooks.py
@@ -13,12 +13,13 @@ get_notification_config = "ferum_customs.notifications.notifications.get_notific
 
 # ── актуальный список фикстур: только данные, без описаний DocType ──
 fixtures = [
-	"custom_fields.json",
-	"custom_docperm.json",
-	"workflow_service_request.json",
-	"portal_menu_item.json",
-	"role.json",
-	"notification.json",
+        "custom_fields.json",
+        "custom_docperm.json",
+        "workflow_service_request.json",
+        "portal_menu_item.json",
+        "role.json",
+        "notification.json",
+        {"doctype": "DocType", "filters": [["name", "=", "ServiceReportWorkItem"]]},
 ]
 
 


### PR DESCRIPTION
## Summary
- correct the name field in `service_report_work_item.json`
- register `ServiceReportWorkItem` DocType in `hooks.py` fixtures

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685934f07660832887dbf8866952b94f