### PR TITLE
Update CI to use official Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,126 +1,35 @@
+name: tests
 
-name: CI
-
-on:
-  push:
-    branches:
-      - develop
-  pull_request:
-
-concurrency:
-  group: develop-ferum_customs-${{ github.event.number }}
-  cancel-in-progress: true
+on: [push, pull_request]
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    name: Server
+  server:
+    runs-on: ubuntu-22.04
     env:
       SITE_NAME: test_site
       ADMIN_PASSWORD: admin
-      BENCH_PATH: $HOME/frappe-bench
-      ERPNEXT_BRANCH: develop
-      BENCH_ALLOW_ROOT: "yes"
-
-    services:
-      redis-cache:
-        image: redis:alpine
-        ports:
-          - 13000:6379
-      redis-queue:
-        image: redis:alpine
-        ports:
-          - 11000:6379
-      mariadb:
-        image: mariadb:10.6
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
-
     steps:
-      - name: Clone
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Find tests
+      - name: Start stack
         run: |
-          echo "Finding tests"
-          grep -rn "def test" > /dev/null
+          docker compose -f docker-compose.test.yml up -d
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          check-latest: true
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install MariaDB Client
-        env:
-          MARIADB_CLIENT_PKG: mariadb-client
+      - name: Install app + ERPNext + deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y $MARIADB_CLIENT_PKG
+          docker compose exec -T frappe bash -c "
+            bench get-app --branch develop erpnext https://github.com/frappe/erpnext &&
+            bench get-app ferum_customs /workspace &&
+            bench setup requirements --dev &&
+            bench new-site --db-root-password root --admin-password $ADMIN_PASSWORD $SITE_NAME &&
+            bench --site $SITE_NAME install-app erpnext &&
+            bench --site $SITE_NAME install-app ferum_customs &&
+            bench pip install pytest pytest-cov
+          "
 
-      - name: Setup
+      - name: Run tests
         run: |
-          pip install frappe-bench
-          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
-          BENCH_PATH="$HOME/frappe-bench"
-          echo "BENCH_PATH=$BENCH_PATH" >> "$GITHUB_ENV"
-          echo "$BENCH_PATH"
-          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
-          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
-
-      - name: Install
-        working-directory: ${{ env.BENCH_PATH }}
-        run: |
-          bench get-app erpnext --branch "$ERPNEXT_BRANCH" https://github.com/frappe/erpnext
-          bench get-app ferum_customs "$GITHUB_WORKSPACE"
-          bench setup requirements --dev
-          bench new-site --db-root-password root --admin-password "$ADMIN_PASSWORD" "$SITE_NAME"
-          bench --site "$SITE_NAME" install-app erpnext
-          bench --site "$SITE_NAME" install-app ferum_customs
-          bench build
-          bench --site "$SITE_NAME" list-apps
-        env:
-          CI: 'Yes'
-
-      - name: Install test deps
-        working-directory: ${{ env.BENCH_PATH }}
-        run: bench pip install pytest pytest-cov
-
-      - name: Run Tests
-        working-directory: ${{ env.BENCH_PATH }}
-        run: |
-          bench --site "$SITE_NAME" set-config allow_tests true
-          bench --site "$SITE_NAME" run-tests --app ferum_customs
-        env:
-          TYPE: server
+          docker compose exec -T frappe bash -c "
+            bench --site $SITE_NAME set-config allow_tests true &&
+            bench --site $SITE_NAME run-tests --app ferum_customs
+          "

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Users require the following roles:
 
 This app can use GitHub Actions for CI. The following workflows are configured:
 
-- CI: Installs this app and runs unit tests on every push to `develop` branch.
+- CI: Spins up official Frappe containers via `docker-compose.test.yml` and runs unit tests.
 - Linters: Runs [Frappe Semgrep Rules](https://github.com/frappe/semgrep-rules) and [pip-audit](https://pypi.org/project/pip-audit/) on every pull request.
 
 ### Testing

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+
+services:
+  mariadb:
+    image: mariadb:10.6
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+    healthcheck:
+      test: ["CMD", "mariadb-admin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  redis:
+    image: redis:alpine
+
+  frappe:
+    image: frappe/erpnext-worker:v16
+    depends_on:
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    volumes:
+      - ./sites:/home/frappe/frappe-bench/sites
+      - .:/workspace
+    working_dir: /home/frappe/frappe-bench
+    command: sleep infinity

--- a/ferum_customs/ferum_customs/doctype/service_report_work_item/service_report_work_item.json
+++ b/ferum_customs/ferum_customs/doctype/service_report_work_item/service_report_work_item.json
@@ -1,6 +1,6 @@
 {
     "doctype": "DocType",
-    "name": "ServiceReportWorkItem",
+    "name": "Service Report Work Item",
     "module": "Ferum Customs",
     "istable": 1,
     "engine": "InnoDB",


### PR DESCRIPTION
## Summary
- switch CI workflow to official `frappe/erpnext-worker` container
- add a lightweight `docker-compose.test.yml`
- fix Service Report Work Item DocType name
- mention new container-based workflow in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68593a351e7083288455890fa5eeeb1b