### PR TITLE
Fix CI workflow env-file and apply lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ on: [push, pull_request]
 jobs:
   server:
     runs-on: ubuntu-22.04
-    env-file: .env
+    env:
+      SITE_NAME: test_site
+      ADMIN_PASSWORD: admin
     steps:
       - uses: actions/checkout@v4
 

--- a/ferum_customs/hooks.py
+++ b/ferum_customs/hooks.py
@@ -13,10 +13,10 @@ get_notification_config = "ferum_customs.notifications.notifications.get_notific
 
 # ── актуальный список фикстур: только данные, без описаний DocType ──
 fixtures = [
-    {
-        "doctype": "DocType",
-        "filters": [["name", "=", "Service Report Work Item"]],
-    },
+	{
+		"doctype": "DocType",
+		"filters": [["name", "=", "Service Report Work Item"]],
+	},
 ]
 
 

--- a/tests/e2e/test_placeholder.py
+++ b/tests/e2e/test_placeholder.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-
 @pytest.mark.slow
 def test_e2e_placeholder():
-        assert 3 == 3
+	assert 3 == 3


### PR DESCRIPTION
## Summary
- run pre-commit and commit ruff formatting fixes
- remove invalid `env-file` key from CI workflow

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/unit`
- `act push -j server` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593ec44e548328ab735064f4bd9fb5