### PR TITLE
Update ERPNext worker tag and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
             ${{ runner.os }}-docker-
 
       - name: Pull images
-        run: docker compose --env-file .env -f docker-compose.test.yml pull
+        run: docker compose --env-file .env -f docker-compose.test.yml pull \
+          || { echo "::error::Image pull failed"; exit 1; }
 
       - name: Start stack
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
+      - name: Validate Docker tag
+        run: |
+          TAG=$(grep 'erpnext-worker:' docker-compose.test.yml | cut -d':' -f3)
+          if ! curl -fsSL "https://registry.hub.docker.com/v2/repositories/frappe/erpnext-worker/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG does not exist on Docker Hub"; exit 1
+          fi
       - name: Validate pyproject
         run: |
           python - <<'PY'

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ folder. See [backup.md](backup.md) for details.
 
 Release notes are tracked in [CHANGELOG.md](CHANGELOG.md).
 
+### Обновление образа
+
+1. Проверьте доступность нового тега:
+
+   ```bash
+   docker pull frappe/erpnext-worker:<new-tag>
+   ```
+
+2. Обновите тег в `docker-compose.test.yml`.
+3. Запустите `pytest` локально и убедитесь, что тесты проходят.
+4. Создайте PR и проверьте, что CI зелёный.
+
 
 ### License
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,7 +20,7 @@ services:
       retries: 10
 
   frappe:
-    image: frappe/erpnext-worker:v16.21.1
+    image: frappe/erpnext-worker:v16.24.2
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- update Docker tag in `docker-compose.test.yml`
- fail fast on Docker pull failures
- verify ERPNext tag exists in linter job
- document how to update the image tag

## Testing
- `pytest -q`
- `pre-commit run --files docker-compose.test.yml .github/workflows/ci.yml .github/workflows/linter.yml README.md`

------
https://chatgpt.com/codex/tasks/task_e_685940318e7c832898c621ed0d55e806