### PR TITLE
Fix ERPNext version mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,18 @@ jobs:
         run: |
           docker compose --env-file .env -f docker-compose.test.yml up -d
 
+      - name: Derive ERPNext branch from Docker tag
+        id: erpnext_branch
+        run: |
+          TAG=$(grep 'erpnext-worker:' docker-compose.test.yml | cut -d':' -f3)
+          MAJOR=$(echo "$TAG" | sed 's/^v\([0-9]*\).*/\1/')
+          echo "branch=version-$MAJOR" >> "$GITHUB_OUTPUT"
+
       - name: Install app + ERPNext + deps
         run: |
           docker compose exec -T frappe bash -c "
             source /workspace/.env &&
-            bench get-app --branch version-16 erpnext https://github.com/frappe/erpnext &&
+            bench get-app --branch ${{ steps.erpnext_branch.outputs.branch }} erpnext https://github.com/frappe/erpnext &&
             bench get-app ferum_customs /workspace &&
             bench setup requirements --dev &&
             bench new-site --db-root-password root --admin-password $ADMIN_PASSWORD $SITE_NAME &&

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,8 +5,8 @@ This document explains how to install the `ferum_customs` app in your Frappe/ERP
 ## Requirements
 
 - Требуется **Frappe + ERPNext**.
-- Tested with **Frappe/ERPNext 15.0**. Older versions are not officially supported.
-- ERPNext branch must match your Frappe version (e.g. `version-15`).
+- Tested with **Frappe/ERPNext 16.0**. Older versions are not officially supported.
+- ERPNext branch must match your Frappe version (e.g. `version-16`).
 - A working [bench](https://github.com/frappe/bench) setup.
 
 ## Bare-metal

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd $PATH_TO_YOUR_BENCH
 bench get-app $URL_OF_THIS_REPO --branch main
 # ERPNext branch should match your installed Frappe version
 bench get-app erpnext --branch version-XX https://github.com/frappe/erpnext
-# Replace XX with your Frappe major version, e.g. 15
+# Replace XX with your Frappe major version, e.g. 16
 bench install-app ferum_customs
 # Run all bench commands from within your bench directory so that the correct
 # Python environment is used

--- a/ferum_customs/ferum_customs/report/engineer_workload/engineer_workload.py
+++ b/ferum_customs/ferum_customs/report/engineer_workload/engineer_workload.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 import frappe
 from frappe import _
 
+from ferum_customs.constants import STATUS_OTMENENA, STATUS_ZAKRYTA
+
 
 def execute(filters=None):
 	rows = frappe.db.sql(
 		"""
         select custom_assigned_engineer as engineer, count(*) as total
         from `tabservice_request`
-        where status not in ('Закрыта', 'Отменена')
+        where status not in (%s, %s)
           and custom_assigned_engineer is not null
         group by custom_assigned_engineer
         order by total desc
         """,
+		(STATUS_ZAKRYTA, STATUS_OTMENENA),
 		as_dict=True,
 	)
 

--- a/ferum_customs/ferum_customs/report/service_request_overview/service_request_overview.py
+++ b/ferum_customs/ferum_customs/report/service_request_overview/service_request_overview.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 import frappe
 from frappe import _
 
+from ferum_customs.constants import STATUS_OTMENENA, STATUS_ZAKRYTA
+
 
 def execute(filters=None):
 	open_count = frappe.db.count(
 		"service_request",
-		{"status": ["not in", ("Закрыта", "Отменена")]},
+		{"status": ["not in", (STATUS_ZAKRYTA, STATUS_OTMENENA)]},
 	)
 	overdue_count = frappe.db.count(
 		"service_request",
 		{
-			"status": ["not in", ("Закрыта", "Отменена")],
+			"status": ["not in", (STATUS_ZAKRYTA, STATUS_OTMENENA)],
 			"planned_end_datetime": ("<", frappe.utils.now_datetime()),
 		},
 	)


### PR DESCRIPTION
## Summary
- keep CI ERPNext version in sync with Docker config
- avoid magic strings in reports by using constants
- update docs to ERPNext v16

## Testing
- `pre-commit run --files ferum_customs/ferum_customs/report/service_request_overview/service_request_overview.py ferum_customs/ferum_customs/report/engineer_workload/engineer_workload.py README.md INSTALL.md .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859495237888328a8300e7b63fed55a