### PR TITLE
Pin ERPNext tag in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     env:
       SITE_NAME: test_site
       ADMIN_PASSWORD: admin
+      ERPNEXT_TAG: version-15
     steps:
       - uses: actions/checkout@v4
 
@@ -18,6 +19,9 @@ jobs:
           key: ${{ runner.os }}-docker-${{ hashFiles('docker-compose.test.yml') }}
           restore-keys: |
             ${{ runner.os }}-docker-
+
+      - name: Validate image tag
+        run: docker manifest inspect frappe/erpnext-worker:${{ env.ERPNEXT_TAG }} >/dev/null
 
       - name: Pull images
         run: docker compose --env-file .env -f docker-compose.test.yml pull 
@@ -30,9 +34,7 @@ jobs:
       - name: Derive ERPNext branch from Docker tag
         id: erpnext_branch
         run: |
-          TAG=$(grep 'erpnext-worker:' docker-compose.test.yml | cut -d':' -f3)
-          MAJOR=$(echo "$TAG" | sed 's/^v\([0-9]*\).*/\1/')
-          echo "branch=version-$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "branch=${ERPNEXT_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Install app + ERPNext + deps
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,6 +16,8 @@ jobs:
     name: 'Frappe Linter'
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    env:
+      ERPNEXT_TAG: version-15
 
     steps:
       - uses: actions/checkout@v4
@@ -25,10 +27,8 @@ jobs:
           cache: pip
       - name: Validate Docker tag
         run: |
-          TAG=$(grep 'erpnext-worker:' docker-compose.test.yml | cut -d':' -f3)
-          if ! curl -fsSL "https://registry.hub.docker.com/v2/repositories/frappe/erpnext-worker/tags/$TAG" >/dev/null; then
-            echo "::error::Tag $TAG does not exist on Docker Hub"; exit 1
-          fi
+          TAG=${ERPNEXT_TAG:-version-15}
+          docker manifest inspect frappe/erpnext-worker:$TAG >/dev/null
       - name: Validate pyproject
         run: |
           python - <<'PY'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,8 @@
 version: "3.9"
 
+x-erpnext-tag: &erp_tag ${ERPNEXT_TAG:-version-15}
+x-erpnext-worker-image: &erpnext_worker_image "frappe/erpnext-worker:${ERPNEXT_TAG:-version-15}"
+
 services:
   mariadb:
     image: mariadb:10.6
@@ -20,7 +23,7 @@ services:
       retries: 10
 
   frappe:
-    image: frappe/erpnext-worker:v16
+    image: *erpnext_worker_image
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- pin ERPNext images to `version-15`
- keep version in one variable in compose file
- use the same tag in CI workflows
- validate image tags in CI

## Testing
- `pre-commit run --files docker-compose.test.yml .github/workflows/ci.yml .github/workflows/linter.yml`
- `ERPNEXT_TAG=version-15 docker compose -f docker-compose.test.yml pull` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595286ff0483288c67c5f27540577d