### PR TITLE
Update ERPNext tag usage

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 SITE_NAME=test_site
 ADMIN_PASSWORD=admin
+
+ERPNEXT_TAG=v15.37.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       SITE_NAME: test_site
       ADMIN_PASSWORD: admin
-      ERPNEXT_TAG: version-15
+      ERPNEXT_TAG: v15.37.0
     steps:
       - uses: actions/checkout@v4
 
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-docker-
 
-      - name: Validate image tag
+      - name: Validate tag
         run: docker manifest inspect frappe/erpnext-worker:${{ env.ERPNEXT_TAG }} >/dev/null
 
       - name: Pull images

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,8 +1,3 @@
-version: "3.9"
-
-x-erpnext-tag: &erp_tag ${ERPNEXT_TAG:-version-15}
-x-erpnext-worker-image: &erpnext_worker_image "frappe/erpnext-worker:${ERPNEXT_TAG:-version-15}"
-
 services:
   mariadb:
     image: mariadb:10.6
@@ -23,7 +18,7 @@ services:
       retries: 10
 
   frappe:
-    image: *erpnext_worker_image
+    image: frappe/erpnext-worker:${ERPNEXT_TAG}
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- set ERPNEXT_TAG version in `.env`
- update docker compose to use this tag explicitly and drop deprecated `version` key
- verify tag in CI before pulling images

## Testing
- `pre-commit run --files .env docker-compose.test.yml .github/workflows/ci.yml`
- `pytest -m 'not slow'`

------
https://chatgpt.com/codex/tasks/task_e_685954e879e8832895529ebd95d0a579