### PR TITLE
Update Docker image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           docker compose exec -T frappe bash -c "
             source /workspace/.env &&
-            bench get-app --branch ${{ steps.erpnext_branch.outputs.branch }} erpnext https://github.com/frappe/erpnext &&
+            bench get-app --branch v15 erpnext https://github.com/frappe/erpnext &&
             bench get-app ferum_customs /workspace &&
             bench setup requirements --dev &&
             bench new-site --db-root-password root --admin-password $ADMIN_PASSWORD $SITE_NAME &&

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,8 +27,12 @@ jobs:
           cache: pip
       - name: Validate Docker tag
         run: |
-          TAG=${ERPNEXT_TAG:-version-15}
-          docker manifest inspect frappe/erpnext-worker:$TAG >/dev/null
+          IMAGE_TAG=$(grep 'image:' docker-compose.test.yml | cut -d' ' -f2)
+          IMAGE_NAME=$(echo $IMAGE_TAG | cut -d':' -f1)
+          TAG=$(echo $IMAGE_TAG | cut -d':' -f2)
+          if ! curl -fsSL "https://registry.hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$TAG" >/dev/null; then
+            echo "::error::Image $IMAGE_NAME with tag $TAG does not exist on Docker Hub"; exit 1
+          fi
       - name: Validate pyproject
         run: |
           python - <<'PY'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   frappe:
-    image: frappe/erpnext-worker:${ERPNEXT_TAG}
+    image: frappe/erpnext:v15
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- set fixed frappe/erpnext image to v15 in test compose file
- switch `bench get-app` to use the v15 branch
- update Docker tag validation in linter workflow

## Testing
- `pytest -q tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_685956c500f88328ae02314eacba4791