### PR TITLE
Add local setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ jspm_packages/
 
 # Aider AI Chat
 .aider*
+
+# Local frappe_docker clone
+frappe_docker/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ bench get-app erpnext --branch version-XX https://github.com/frappe/erpnext
 bench install-app ferum_customs
 # Run all bench commands from within your bench directory so that the correct
 # Python environment is used
+
 ```
+Alternatively, run `scripts/setup_environment.sh` from your bench directory to automate these steps.
+
 ### Запуск в Docker
 
 Run the stack with:

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This script sets up a Frappe/ERPNext bench with the ferum_customs app.
+
+set -euo pipefail
+
+APP_REPO="https://github.com/Dmitriyrus99/ferum_customs.git"
+APP_BRANCH="main"
+ERPNEXT_REPO="https://github.com/frappe/erpnext"
+ERPNEXT_BRANCH="version-16"
+
+SITE_NAME="${SITE_NAME:-test_site}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+DB_ROOT_PASSWORD="${DB_ROOT_PASSWORD:-root}"
+
+if ! command -v bench >/dev/null; then
+    echo "Error: bench command not found. Please install Frappe bench first." >&2
+    exit 1
+fi
+
+# Get apps
+bench get-app "$APP_REPO" --branch "$APP_BRANCH"
+bench get-app erpnext --branch "$ERPNEXT_BRANCH" "$ERPNEXT_REPO"
+
+# Create a new site and install applications
+bench new-site "$SITE_NAME" \
+    --admin-password "$ADMIN_PASSWORD" \
+    --mariadb-root-password "$DB_ROOT_PASSWORD"
+
+bench --site "$SITE_NAME" install-app erpnext
+bench --site "$SITE_NAME" install-app ferum_customs
+
+# Build assets and restart bench
+bench build && bench restart
+
+echo "ferum_customs installed successfully on site '$SITE_NAME'."
+


### PR DESCRIPTION
## Summary
- provide `setup_environment.sh` to automate bench installation
- ignore local `frappe_docker` directory
- document usage of the setup script

## Testing
- `pip install -r requirements-dev.txt`
- `pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_685966f2dec08328ae653c4ee0711230