### PR TITLE
Fix ERPNext clone logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,24 @@ jobs:
             set -e
             source /workspace/.env
 
-            # --- ERPNext ---------------------------------------------------------
+            # --- ERPNext ----------------------------------------------------
             if [ ! -d apps/erpnext ]; then
                 echo "ERPNext not found — cloning..."
                 bench get-app --branch "${ERPNEXT_TAG}" erpnext https://github.com/frappe/erpnext
+            elif [ ! -d apps/erpnext/.git ]; then
+                echo "ERPNext present but not a git repo — replacing..."
+                rm -rf apps/erpnext
+                bench get-app --branch "${ERPNEXT_TAG}" erpnext https://github.com/frappe/erpnext
             else
-                echo "ERPNext already present — ensuring correct tag ${ERPNEXT_TAG}"
+                echo "ERPNext git repo detected — switching to tag ${ERPNEXT_TAG}"
                 cd apps/erpnext
                 git fetch --depth=1 origin "${ERPNEXT_TAG}"
                 git checkout -q "${ERPNEXT_TAG}"
                 cd -
-                bench setup requirements --node --python --overwrite
             fi
+
+            # обновляем зависимости под актуальный код
+            bench setup requirements --node --python --overwrite
 
             # --- Ваша кастомная аппка -------------------------------------------
             bench get-app ferum_customs /workspace


### PR DESCRIPTION
## Summary
- add checks in CI to reset ERPNext directory when no git repo

## Testing
- `pip install -r requirements-dev.txt`
- `bench --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685973fd98f08328986305bbef03a466