### PR TITLE
Add bench permissions fix in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
             set -e
             source /workspace/.env
 
+            # --- 1. Fix ownership so user frappe can write bench dir ---
+            echo "Fixing ownership for frappe-bench …"
+            sudo chown -R frappe:frappe /home/frappe/frappe-bench
+
             # --- ERPNext ----------------------------------------------------
             if [ ! -d apps/erpnext ]; then
                 echo "ERPNext not found — cloning..."


### PR DESCRIPTION
## Summary
- fix ownership for bench directory in CI workflow

## Testing
- `pytest -m "not slow" tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_68597b3dcac483289913942fe8224ba0