### PR TITLE
Fix CI for bench 5.25+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,11 @@ jobs:
             # --- ERPNext ----------------------------------------------------
             if [ ! -d apps/erpnext ]; then
                 echo "ERPNext not found — cloning..."
-                bench get-app --branch "${ERPNEXT_TAG}" --depth 1 erpnext https://github.com/frappe/erpnext
+                bench get-app --branch "${ERPNEXT_TAG}" erpnext https://github.com/frappe/erpnext
             elif [ ! -d apps/erpnext/.git ]; then
                 echo "ERPNext present but not a git repo — replacing..."
                 rm -rf apps/erpnext
-                bench get-app --branch "${ERPNEXT_TAG}" --depth 1 erpnext https://github.com/frappe/erpnext
+                bench get-app --branch "${ERPNEXT_TAG}" erpnext https://github.com/frappe/erpnext
             else
                 echo "ERPNext git repo detected — switching to tag ${ERPNEXT_TAG}"
                 cd apps/erpnext


### PR DESCRIPTION
## Summary
- remove deprecated `--depth` flag when fetching ERPNext in CI

## Testing
- `pytest -q tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_6859827103e08328aba52673d836a0f4