### PR TITLE
Fix DB host for new site in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,13 @@ jobs:
             bench get-app ferum_customs /workspace
 
             # --- dev-зависимости и сайт -----------------------------------------
-            bench new-site --db-root-password "$DB_ROOT_PASSWORD" --admin-password "$ADMIN_PASSWORD" "$SITE_NAME"
+            bench new-site \
+              --db-host mariadb \
+              --db-port 3306 \
+              --no-mariadb-socket \
+              --db-root-password "$DB_ROOT_PASSWORD" \
+              --admin-password "$ADMIN_PASSWORD" \
+              "$SITE_NAME"
             bench --site "$SITE_NAME" install-app erpnext
             bench --site "$SITE_NAME" install-app ferum_customs
 


### PR DESCRIPTION
## Summary
- use the mariadb hostname when creating a site in CI

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_685983e6f97c83288252c770affd6e67