### PR TITLE
Fix docker UID and git safe.directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: docker compose -f docker-compose.test.yml up -d
 
       - name: Allow git access to workspace
-        run: docker compose exec -T frappe git config --global --add safe.directory /workspace
+        run: docker compose exec -T frappe bash -c 'if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git config --global --add safe.directory /workspace; fi'
 
       - name: Install apps and dependencies
         run: |

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -29,5 +29,6 @@ services:
     volumes:
       - ./sites:/home/frappe/frappe-bench/sites
       - .:/workspace
+    user: "${UID:-1000}:${GID:-1000}"
     working_dir: /home/frappe/frappe-bench
     command: sleep infinity


### PR DESCRIPTION
## Summary
- sync UID/GID for the test stack
- avoid git warnings when not in a repo

## Testing
- `pip install -r requirements-dev.txt`
- `bench --site test_site run-tests --app ferum_customs --tests-path tests/unit` *(fails: `bench` command not properly set up)*

------
https://chatgpt.com/codex/tasks/task_e_6859912e45548328885347b84504fe95