### PR TITLE
Fix CI env variable and git safe dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     name: Run Server-Side Tests
 
     env:
+      SITE_NAME: tests.local
       FRAPPE_SITE_NAME: tests.local
       ADMIN_PASSWORD: admin
       ERPNEXT_TAG: v15.65.4
@@ -57,8 +58,6 @@ jobs:
       - name: Start Docker stack
         run: docker compose -f docker-compose.test.yml up -d
 
-      - name: Allow git access to workspace
-        run: docker compose exec -T frappe bash -c 'cd apps/ferum_customs && git config --global --add safe.directory $(pwd)'
 
       - name: Install apps and dependencies
         run: |

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -31,4 +31,8 @@ services:
       - .:/home/frappe/frappe-bench/apps/ferum_customs
     user: "${UID:-1000}:${GID:-1000}"
     working_dir: /home/frappe/frappe-bench
+    entrypoint: >
+      bash -c "
+        git config --global --add safe.directory /home/frappe/frappe-bench/apps/ferum_customs &&
+        exec docker-entrypoint.sh"
     command: sleep infinity


### PR DESCRIPTION
## Summary
- unify site env variables across compose and workflow
- set git safe directory in compose entrypoint
- remove redundant step from workflow

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`
- `pre-commit run --files .github/workflows/ci.yml docker-compose.test.yml`


------
https://chatgpt.com/codex/tasks/task_e_685996ef289c83289f0607d6bc62fc0e