### PR TITLE
Fix CI site recreation & container permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Install apps and dependencies
         run: |
-          docker compose exec -T --user root frappe chown -R frappe:frappe /home/frappe/frappe-bench
           docker compose exec -T -e GITHUB_REF_NAME=$GITHUB_REF_NAME frappe bash -eo pipefail -c '
             set -e
             source apps/ferum_customs/.env
@@ -76,7 +75,11 @@ jobs:
             else
                 bench get-app --branch "$GITHUB_REF_NAME" --overwrite ferum_customs https://github.com/${{ github.repository }}.git
             fi
-            bench new-site --db-root-password "$DB_ROOT_PASSWORD" --admin-password "$ADMIN_PASSWORD" "$FRAPPE_SITE_NAME"
+            if bench --site "$FRAPPE_SITE_NAME" exist >/dev/null 2>&1; then
+                bench drop-site "$FRAPPE_SITE_NAME" --root-password "$DB_ROOT_PASSWORD" --force
+            fi
+            bench new-site --db-root-password "$DB_ROOT_PASSWORD" \
+               --admin-password "$ADMIN_PASSWORD" "$FRAPPE_SITE_NAME"
             bench --site "$FRAPPE_SITE_NAME" install-app erpnext
             bench --site "$FRAPPE_SITE_NAME" install-app ferum_customs
             bench pip install -q pytest pytest-cov

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       dockerfile: Dockerfile.frappe
       args:
         - PYTHON_VERSION=3.11
-    user: "1000:1000"
+    user: "${UID:-1000}:${GID:-1000}"
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- handle site recreation in CI workflow
- drop root chown step in CI workflow
- run containers with runner's UID/GID

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685997f51c788328b058d58605a600fb