### PR TITLE
Update Buildx version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Set up compose v2.27
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-          version: v2.27.0
+          version: v0.14.0      # ✅ существующий релиз
 
       - name: Cache pip packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- ensure Docker Buildx uses v0.14.0 in CI workflow

## Testing
- `pip install -r requirements-dev.txt`
- `bench --site test_site run-tests --app ferum_customs --tests-path tests/unit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685999eaf8cc8328b6ade7c1416af7ee