### PR TITLE
Fix fixture path for bench tests

### DIFF
--- a/tests/unit/test_portal_menu_roles.py
+++ b/tests/unit/test_portal_menu_roles.py
@@ -1,7 +1,10 @@
 import json
 from pathlib import Path
 
-FIXTURE_PATH = Path("ferum_customs/fixtures")
+# Compute absolute path to fixtures so tests work regardless of CWD
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2] / "ferum_customs" / "fixtures"
+)
 
 
 def load_fixture(name: str):


### PR DESCRIPTION
## Summary
- make fixture path absolute so tests run under bench

## Testing
- `pytest -q tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_6859a131517c832895d2a3458a69ecc6