### PR TITLE
Fix Bench tag in CI and Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       FRAPPE_SITE_NAME: tests.local
       ADMIN_PASSWORD: admin
       ERPNEXT_TAG: v15.65.4
-      BENCH_TAG: v5.26.0
+      BENCH_TAG: v5.25.4
       DB_ROOT_PASSWORD: root
 
     steps:

--- a/Dockerfile.frappe
+++ b/Dockerfile.frappe
@@ -1,4 +1,4 @@
-FROM frappe/bench:v5.26.0
+FROM frappe/bench:v5.25.4
 
 # Install Python 3.11 and dev dependencies if needed
 ARG PYTHON_VERSION=3.11


### PR DESCRIPTION
## Summary
- point Bench tag at a published release

## Testing
- `pytest -q tests/unit -vv`

------
https://chatgpt.com/codex/tasks/task_e_6859a169b9108328b25ea28ce013775a