### PR TITLE
Fix ERPNext branch for develop

### DIFF
--- a/Dockerfile.frappe
+++ b/Dockerfile.frappe
@@ -24,7 +24,7 @@ RUN bench init --skip-assets frappe-bench --python $(which python)
 WORKDIR /home/frappe/frappe-bench
 
 # Clone applications
-RUN bench get-app --branch version-16 erpnext https://github.com/frappe/erpnext
+RUN bench get-app --branch develop erpnext https://github.com/frappe/erpnext
 
 # Add the local app during build
 COPY --chown=frappe:frappe . /home/frappe/frappe-bench/apps/ferum_customs


### PR DESCRIPTION
## Summary
- point docker build to ERPNext develop branch for Frappe develop

## Testing
- `pip install -r requirements-dev.txt`
- `pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_685a4b4e27d08328a1850a947ce9eab7