### PR TITLE
Fix CI entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,11 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          docker compose run --rm frappe \
-            pip install -q pytest pytest-cov
+          docker compose run --rm frappe pip install -q pytest pytest-cov
 
       - name: Run tests
         run: |
-          docker compose --env-file .env -f docker-compose.test.yml \
-            run --rm frappe bash -c "pytest -q --cov"
+          docker compose --env-file .env -f docker-compose.test.yml run --rm frappe bash -c "pytest -q --cov"
 
       - name: Cleanup
         run: docker compose -f docker-compose.test.yml down -v

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -36,7 +36,4 @@ services:
       - .:/home/frappe/frappe-bench/apps/ferum_customs
     user: "${UID:-1000}:${GID:-1000}"
     working_dir: /home/frappe/frappe-bench
-    entrypoint: >
-      bash -c "
-        git config --global --add safe.directory /home/frappe/frappe-bench/apps/ferum_customs &&
-        exec docker-entrypoint.sh"
+    entrypoint: /entrypoint.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests-oauthlib==2.0.0  # satisfies frappe 16.x


### PR DESCRIPTION
## Summary
- update the CI Docker entrypoint
- keep test commands on one line
- pin `requests-oauthlib` version for compatibility

## Testing
- `pre-commit run --files docker-compose.test.yml .github/workflows/ci.yml requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a504d65288328a0dac11b967ac749