### PR TITLE
Fix entrypoint path for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ This app can use GitHub Actions for CI. The following workflows are configured:
 4. В стадии «Install app + deps» уже запущен корректный образ Frappe, поэтому `bench` доступен внутри контейнера.
 5. Тесты выполняются через `docker compose run --rm frappe ... pytest` и должны проходить так же, как локально при `pytest -m "not slow"`.
 
-Чтобы сохранить ENTRYPOINT образа и всё же передавать собственные команды, в `docker-compose.test.yml` явно указан путь к скрипту запуска:
+Чтобы передавать собственные команды и при этом использовать сценарий запуска образа, в `docker-compose.test.yml` указан явный путь к скрипту запуска:
 
 ```yaml
 services:
   frappe:
-    entrypoint: ["tini", "--", "/usr/local/bin/docker-entrypoint.py"]
+    entrypoint: ["/usr/local/bin/docker-entrypoint.py"]
 ```
 
 ### Testing

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -36,5 +36,5 @@ services:
       - .:/home/frappe/frappe-bench/apps/ferum_customs
     user: "${UID:-1000}:${GID:-1000}"
     working_dir: /home/frappe/frappe-bench
-    # Explicit default ENTRYPOINT so we can pass custom commands
-    entrypoint: ["tini", "--", "/usr/local/bin/docker-entrypoint.py"]
+  # Use image's entrypoint script directly for custom commands
+  entrypoint: ["/usr/local/bin/docker-entrypoint.py"]


### PR DESCRIPTION
## Summary
- fix Docker compose entrypoint script path
- update README instructions

## Testing
- `pytest -m "not slow" tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_685c1b0f6a1c8328a5f103a4d3ee346f