### PR TITLE
Fix compose entrypoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ This app can use GitHub Actions for CI. The following workflows are configured:
 4. В стадии «Install app + deps» уже запущен корректный образ Frappe, поэтому `bench` доступен внутри контейнера.
 5. Тесты выполняются через `docker compose run --rm frappe ... pytest` и должны проходить так же, как локально при `pytest -m "not slow"`.
 
-Чтобы передавать собственные команды и при этом использовать сценарий запуска образа, в `docker-compose.test.yml` указан явный путь к скрипту запуска:
+Чтобы передавать собственные команды и при этом использовать сценарий запуска образа, в `docker-compose.test.yml` указан явный путь к скрипту `nginx-entrypoint.sh`:
 
 ```yaml
 services:
   frappe:
-    entrypoint: ["/usr/local/bin/docker-entrypoint.py"]
+    entrypoint: ["/usr/local/bin/nginx-entrypoint.sh"]
 ```
 
 ### Testing

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,4 +37,4 @@ services:
     user: "${UID:-1000}:${GID:-1000}"
     working_dir: /home/frappe/frappe-bench
     # Use image's entrypoint script directly for custom commands
-    entrypoint: ["/usr/local/bin/docker-entrypoint.py"]
+    entrypoint: ["/usr/local/bin/nginx-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- use correct `nginx-entrypoint.sh` in compose test config
- update README entrypoint snippet

## Testing
- `pre-commit run --files README.md docker-compose.test.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2e3ad3888328ac9f0d4a810ed941