### PR TITLE
Restructure project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,176 +1,115 @@
-### ferum_customs
+# Ferum Customs
 
 ![CI](https://github.com/<owner>/ferum_customs/actions/workflows/ci.yml/badge.svg)
 ![Coverage](https://img.shields.io/badge/coverage-unknown-lightgrey.svg)
 
-Ferum Customs adds a service management layer to ERPNext. The app helps keep
-a registry of serviced equipment, register incoming requests and collect reports
-about the work performed. All documents are linked so that a Service Request
-always refers to a Service Object and can be closed with a Service Report. The
-workflow takes a request from "Открыта" to "Закрыта".
+Ferum Customs extends ERPNext with a service management layer. It keeps a registry of serviced equipment, tracks incoming requests and stores reports about performed work.
 
-Key DocTypes and their relations:
+## Key DocTypes
 
-- **Service Object** — equipment or site that requires maintenance.
-- **Service Request** — a ticket linked to a Service Object describing required
-  work.
+- **Service Object** — equipment or a site that requires maintenance.
+- **Service Request** — a ticket linked to a Service Object describing required work.
 - **Service Report** — a record of work done for a request.
 - **Service Project** — optional container to group multiple requests.
 
-### Installation
+## Requirements
 
-You can install this app using the [bench](https://github.com/frappe/bench) CLI:
+- Frappe + ERPNext 16.x or later.
+- Matching ERPNext branch (e.g. `version-16`).
+- A working [bench](https://github.com/frappe/bench) setup if installing without Docker.
+
+## Installation
+
+### Using bench
 
 ```bash
-cd $PATH_TO_YOUR_BENCH
-bench get-app $URL_OF_THIS_REPO --branch main
-# ERPNext branch should match your installed Frappe version
-bench get-app erpnext --branch version-XX https://github.com/frappe/erpnext
-# Replace XX with your Frappe major version, e.g. 16
-bench install-app ferum_customs
-# Run all bench commands from within your bench directory so that the correct
-# Python environment is used
-
+bench get-app https://github.com/Dmitriyrus99/ferum_customs.git --branch main
+bench --site YOUR_SITE_NAME install-app ferum_customs
+bench build && bench restart
 ```
-Alternatively, run `scripts/setup_environment.sh` to spin up a Docker-based bench and install this app automatically. The script clones `frappe_docker`, starts the containers and creates the site for you.
 
+### Using Docker
 
-### Запуск в Docker
+Run the stack locally:
 
-Run the stack with:
 ```bash
-docker compose up -d
+docker compose up -d --build
 ```
 
-To replicate the CI environment locally run:
-```bash
-docker compose -f docker-compose.test.yml up -d
-```
+The helper script `scripts/setup_environment.sh` can bootstrap a development bench in Docker and install the app automatically.
 
-When Frappe releases a new minor version, update the `image` tag in
-`docker-compose.test.yml` to that version and rebuild the containers.
+Add `ferum_customs` to `apps.txt` (or `apps.json`) if you build custom images.
 
+## Usage
 
-### Contributing
+After installation the **Ferum Customs** module appears on the ERPNext desk. Typical workflow:
 
-This app uses `pre-commit` for code formatting and linting. Please [install pre-commit](https://pre-commit.com/#installation) and enable it for this repository:
+1. Create a **Service Object** that represents equipment or a location.
+2. Open a **Service Request** for that object.
+3. Technicians submit **Service Reports** describing the work done.
+4. Optionally group several requests in a **Service Project**.
+
+Roles required:
+
+- **Проектный менеджер** or **System Manager** — manage all documents and the workflow.
+- **Service Engineer** — update assigned requests and submit reports.
+- **Customer** — view their own requests and related reports.
+
+## Development
+
+Pre‑commit hooks format and lint the code. Enable them inside the app directory:
 
 ```bash
 cd apps/ferum_customs
 pre-commit install
 ```
 
-Pre-commit is configured to use the following tools for checking and formatting your code:
+When editing configuration files on a server use `vi` or `vim` instead of `nano`.
 
-- ruff
-- eslint
-- prettier
-- pyupgrade
+Project source lives inside the `ferum_customs` package. Key folders include `custom_logic` for DocType hooks, `fixtures` for exported records and `workflow` for workflow configuration.
 
-### CLI Tips
+### Running tests
 
-When editing configuration files on the server, use **vi** or **vim** instead of
-`nano`, which might not be available by default.
+Quick unit tests can be executed with bench:
 
-### Project Structure
-
-All application code lives inside the `ferum_customs` package. Important
-subdirectories include:
-
-- `custom_logic` – Python hooks used by DocType events
-- `ferum_customs/doctype` – definitions of custom DocTypes
-- `fixtures` – exported records such as roles and custom fields
-- `workflow` and `workspace` – workflow configuration and Desk shortcuts
-
-The `update` folder from the original archive has been merged into these
-subdirectories.
-
-### Usage
-
-After installing the app you will see a new **Ferum Customs** module on the
-ERPNext desk. Typical workflow looks as follows:
-
-1. Create a **Service Object** that represents equipment or a location.
-2. Open a **Service Request** for that object.
-3. Technicians update the request and submit **Service Reports** describing the
-   work done.
-4. Optionally group several requests in a **Service Project**.
-
-Users require the following roles:
-
-- **Проектный менеджер** or **System Manager** — manage all documents and the
-  workflow.
-- **Service Engineer** — update assigned Service Requests and submit reports.
-- **Customer** — view their own Service Requests and related reports.
-### CI
-
-This app can use GitHub Actions for CI. The following workflows are configured:
-
-- CI: Spins up official Frappe containers via `docker-compose.test.yml` and runs unit tests.
-- Linters: Runs [Frappe Semgrep Rules](https://github.com/frappe/semgrep-rules) and [pip-audit](https://pypi.org/project/pip-audit/) on every pull request.
-
-#### Быстрый чек-лист
-
-Перед запуском workflow убедитесь, что:
-
-1. Скопируйте `.env.example` в `.env` и убедитесь, что указан существующий тег ERPNext. Проверьте его командой:
-
-   ```bash
-   docker pull frappe/erpnext:${ERPNEXT_TAG}
-   ```
-
-2. Первый шаг `chown` в CI использует `docker compose exec -T --user root frappe chown ...`.
-3. Значение `ERPNEXT_TAG` в логе совпадает с переменной в workflow, иначе будет «tag not found».
-4. В стадии «Install app + deps» уже запущен корректный образ Frappe, поэтому `bench` доступен внутри контейнера.
-5. Тесты выполняются через `docker compose run --rm frappe ... pytest` и должны проходить так же, как локально при `pytest -m "not slow"`.
-
-Чтобы передавать собственные команды и при этом использовать сценарий запуска образа, в `docker-compose.test.yml` указан явный путь к скрипту `nginx-entrypoint.sh`:
-
-```yaml
-services:
-  frappe:
-    entrypoint: ["/usr/local/bin/nginx-entrypoint.sh"]
+```bash
+bench --site <site> run-tests --app ferum_customs --tests-path tests/unit
 ```
 
-### Testing
-
-Unit tests can be run locally with `pytest` or through bench. From the
-repository root execute:
+You can also run the whole suite with `pytest`:
 
 ```bash
 pytest
 ```
 
-If you prefer using bench:
+## CI
+
+GitHub Actions start containers defined in `docker-compose.test.yml` and run unit tests. The same stack can be started locally with:
 
 ```bash
-bench --site <your-site> run-tests apps/ferum_customs
+docker compose -f docker-compose.test.yml up -d
 ```
 
-### Backup
+## Backup and Recovery
 
-Regularly export a SQL dump of your site and copy the `files` directory from the
-bench. To restore, deploy the same version of the app from GitHub, import the
-database dump and place the attachments back into the `sites/<site-name>/public/files`
-folder. See [backup.md](backup.md) for details.
+Export SQL dumps of your site and copy the `files` directory from the bench. To restore, deploy the same version of the app, import the database dump and place attachments back into `sites/<site-name>/public/files`. Details are in [backup.md](backup.md).
 
-### Changelog
+## Updating images
 
-Release notes are tracked in [CHANGELOG.md](CHANGELOG.md).
+To update Docker images:
 
-### Обновление образа
+1. Pull the new tag: `docker pull frappe/erpnext-worker:<new-tag>`
+2. Update the tag in `docker-compose.test.yml` and rebuild containers.
+3. Run `pytest` locally and make sure tests pass before opening a PR.
 
-1. Проверьте доступность нового тега:
+## Changelog
 
-   ```bash
-   docker pull frappe/erpnext-worker:<new-tag>
-   ```
+Release notes live in [CHANGELOG.md](CHANGELOG.md).
 
-2. Обновите тег в `docker-compose.test.yml`.
-3. Запустите `pytest` локально и убедитесь, что тесты проходят.
-4. Создайте PR и проверьте, что CI зелёный.
+## Security
 
+Report vulnerabilities via [support@ferum.ru](mailto:support@ferum.ru). Do not disclose issues publicly until patched.
 
-### License
+## License
 
 MIT. See [license.txt](license.txt) for details.


### PR DESCRIPTION
## Summary
- overhaul README to consolidate installation, usage and development notes
- keep quick unit test command using bench

## Testing
- `bench --site test_site run-tests --app ferum_customs --tests-path tests/unit` *(fails: command not found)*
- `pytest -q tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_685c2f9525208328ba11809fdfd9d1b6