### PR TITLE
Configure PM email alert on Service Request updates

### DIFF
--- a/ferum_customs/notifications/notifications.py
+++ b/ferum_customs/notifications/notifications.py
@@ -20,28 +20,30 @@ def get_notification_config() -> dict:
     """
     return {
         "Service Request": {
-            # Условие для срабатывания уведомления:
-            # Отправлять, когда Service Request находится в одном из указанных статусов.
-            "condition": f"doc.status in ['{STATUS_OTKRYTA}', '{STATUS_V_RABOTE}']",
-            # Получатели:
+            # Отправлять уведомление, только если статус изменился.
+            "condition": (
+                "doc.get_doc_before_save() and "
+                "doc.status != doc.get_doc_before_save().status"
+            ),
+            # Получатели уведомлений
             "send_to_roles": [ROLE_PROEKTNYJ_MENEDZHER],
-            # Сообщение уведомления (можно использовать Jinja шаблонизацию)
-            "subject": _("Обновление по Заявке на обслуживание: {{ doc.name }}"),
+            # Темы и сообщения можно шаблонизировать через Jinja
+            "subject": _(
+                "Статус заявки {{ doc.name }} изменён на {{ doc.status }}"
+            ),
             "message": _(
                 """
-Уважаемый пользователь,
+Здравствуйте!
 
-Информация по заявке на обслуживание <h3>{{ doc.name }}</h3>:
-{% if doc.subject %}Тема: {{ doc.subject }} {% endif %}
-
-Текущий статус: <strong>{{ doc.status }}</strong>.
+Заявка <strong>{{ doc.name }}</strong> изменила статус на
+<strong>{{ doc.status }}</strong>.
 {% if doc.custom_customer %}Клиент: {{ frappe.get_cached_value("Customer", doc.custom_customer, "customer_name") or doc.custom_customer }} {% endif %}
-{% if doc.custom_service_object_link %}Объект обслуживания: {{ doc.custom_service_object_link }} {% endif %}
 {% if doc.custom_assigned_engineer %}Назначенный инженер: {{ frappe.get_cached_value("User", doc.custom_assigned_engineer, "full_name") or doc.custom_assigned_engineer }} {% endif %}
 
-Пожалуйста, просмотрите заявку: {{ frappe.utils.get_link_to_form('Service Request', doc.name) }}
+Открыть заявку: {{ frappe.utils.get_link_to_form('Service Request', doc.name) }}
 
-Спасибо.
+--
+Система Ferum Customs
 """
             ),
         },


### PR DESCRIPTION
## Summary
- adjust notification to fire whenever Service Request status changes
- ensure project managers get a message about the new status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c30bf79908328baa0021caf0e2034