### PR TITLE
Add Telegram bot service and bot API endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests-oauthlib==2.0.0  # satisfies frappe 16.x
+fastapi==0.110.0
+aiogram==3.5.0

--- a/telegram_bot/bot_service.py
+++ b/telegram_bot/bot_service.py
@@ -1,0 +1,82 @@
+"""Minimal Telegram bot service using FastAPI and Aiogram.
+
+This module provides a skeleton implementation of a webhook compatible
+service.  The bot uses Finite State Machines (FSM) for different flows:
+
+* ``IncidentStates`` – reporting incidents.
+* ``TaskStates`` – creating new tasks.
+* ``PhotoStates`` – uploading photos.
+
+It can be extended further to react to Telegram updates and call the
+whitelisted API methods defined in :mod:`ferum_customs.api`.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI
+from aiogram import Bot, Dispatcher
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.fsm.storage.memory import MemoryStorage
+
+
+class IncidentStates(StatesGroup):
+    """Conversation flow for incident reporting."""
+
+    waiting_object = State()
+    waiting_description = State()
+    waiting_photo = State()
+
+
+class TaskStates(StatesGroup):
+    """Conversation flow for task creation."""
+
+    waiting_title = State()
+    waiting_details = State()
+
+
+class PhotoStates(StatesGroup):
+    """Standalone photo upload flow."""
+
+    waiting_photo = State()
+    confirming = State()
+
+
+app = FastAPI(title="Ferum Bot Service")
+
+
+def _create_dispatcher() -> Dispatcher:
+    """Instantiate dispatcher with in‑memory storage."""
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN", "")
+    bot = Bot(token)
+    return Dispatcher(storage=MemoryStorage(), bot=bot)
+
+
+dispatcher = _create_dispatcher()
+
+
+@app.on_event("startup")
+async def startup_event() -> None:  # pragma: no cover - example implementation
+    """Hook that runs on service startup."""
+
+    # Dispatcher can include routers with handlers here.
+    pass
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:  # pragma: no cover - example implementation
+    """Hook that runs on service shutdown."""
+
+    await dispatcher.storage.close()
+
+
+__all__ = [
+    "app",
+    "dispatcher",
+    "IncidentStates",
+    "TaskStates",
+    "PhotoStates",
+]
+


### PR DESCRIPTION
## Summary
- add new `telegram_bot` service with initial FSM state definitions
- expose bot helper endpoints in `api.py`
- include FastAPI and Aiogram dependencies

## Testing
- `ruff check ferum_customs/api.py telegram_bot/bot_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c319346c48328b023a9bb65394405