### PR TITLE
Fix file deletion util

### DIFF
--- a/ferum_customs/custom_logic/file_attachment_utils.py
+++ b/ferum_customs/custom_logic/file_attachment_utils.py
@@ -191,7 +191,10 @@ def on_custom_attachment_trash(doc: FrappeDocument, method: str | None = None):
             file_doc_name = frappe.db.get_value("File", {"file_url": file_url})
             if file_doc_name:
                 frappe.delete_doc(
-                    "File", file_doc_name, ignore_permissions=True, force_delete=True
+                    "File",
+                    file_doc_name,
+                    ignore_permissions=True,
+                    force=True,
                 )
                 logger.info(
                     f"Deleted File DocType record '{file_doc_name}' for CustomAttachment '{doc.name}' (URL: {file_url})."


### PR DESCRIPTION
## Summary
- correct `delete_doc` argument in `on_custom_attachment_trash`

## Testing
- `pip install -r requirements-dev.txt`
- `bench --site test_site run-tests --app ferum_customs --tests-path tests/unit` *(fails: bench not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c32aa80bc832896ef862e4c872b6d