### PR TITLE
Add basic hooks tests and improve setup script

### DIFF
--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -17,6 +17,9 @@ SITE_NAME=${SITE_NAME:-"dev.localhost"}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-"admin"}
 FRAPPE_VERSION="v15"
 ERPNext_VERSION="v15"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ROOT="$(dirname "$SCRIPT_DIR")"
+FERUM_CUSTOMS_PATH="${FERUM_CUSTOMS_PATH:-$APP_ROOT}"
 
 # --- Функция для определения команды docker compose ---
 if docker compose version &> /dev/null; then
@@ -108,6 +111,19 @@ echo "Установка приложения ERPNext на сайт ${SITE_NAME}
 $DC_COMMAND -f pwd.yml exec frappe bench --site "${SITE_NAME}" install-app erpnext
 if [ $? -ne 0 ]; then
     echo "Ошибка: Не удалось установить приложение ERPNext на сайт."
+    exit 1
+fi
+
+echo "Добавление и установка приложения ferum_customs..."
+$DC_COMMAND -f pwd.yml exec frappe bench get-app "$FERUM_CUSTOMS_PATH"
+if [ $? -ne 0 ]; then
+    echo "Ошибка: Не удалось добавить приложение ferum_customs."
+    exit 1
+fi
+
+$DC_COMMAND -f pwd.yml exec frappe bench --site "${SITE_NAME}" install-app ferum_customs
+if [ $? -ne 0 ]; then
+    echo "Ошибка: Не удалось установить приложение ferum_customs."
     exit 1
 fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+import sys
+import types
+
+import pytest
+
+
+class DummyLog:
+    def info(self, *a, **k):
+        pass
+    def warning(self, *a, **k):
+        pass
+    def error(self, *a, **k):
+        pass
+
+@pytest.fixture
+def frappe_stub(monkeypatch):
+    frappe = types.SimpleNamespace()
+    frappe.db = types.SimpleNamespace(
+        exists=lambda *a, **k: None,
+        get_value=lambda *a, **k: None,
+    )
+    class ValidationError(Exception):
+        pass
+    class PermissionError(Exception):
+        pass
+    frappe.ValidationError = ValidationError
+    frappe.PermissionError = PermissionError
+    exc_mod = types.ModuleType("frappe.exceptions")
+    exc_mod.PermissionError = PermissionError
+    sys.modules["frappe.exceptions"] = exc_mod
+    frappe.DoesNotExistError = Exception
+    frappe.throw = lambda msg, exc=None, *a, **k: (_ for _ in ()).throw(
+        exc(msg) if exc else ValidationError(msg)
+    )
+    frappe._ = lambda s: s
+    frappe.logger = lambda name=None: DummyLog()
+    frappe.utils = types.SimpleNamespace(now=lambda: "now")
+    frappe.whitelist = lambda *args, **kwargs: (lambda f: f)
+    frappe.get_doc = lambda *a, **k: None
+    frappe.get_all = lambda *a, **k: []
+    frappe.has_permission = lambda *a, **k: True
+    sys.modules['frappe'] = frappe
+    yield frappe
+    sys.modules.pop('frappe', None)

--- a/tests/e2e/test_service_request_flow.py
+++ b/tests/e2e/test_service_request_flow.py
@@ -1,0 +1,17 @@
+import pytest
+
+frappe = pytest.importorskip("frappe")
+from frappe.tests.utils import FrappeTestCase
+
+from ferum_customs import api
+from ferum_customs.constants import STATUS_OTKRYTA
+
+
+@pytest.mark.slow
+class TestServiceRequestFlow(FrappeTestCase):
+    def test_full_flow(self, frappe_site):
+        sr_name = api.bot_create_service_request("E2E Subject")
+        self.assertTrue(frappe.db.exists("Service Request", sr_name))
+        open_requests = api.bot_get_service_requests(status=STATUS_OTKRYTA)
+        names = [r["name"] for r in open_requests]
+        self.assertIn(sr_name, names)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,14 @@
+import pytest
+
+frappe = pytest.importorskip("frappe")
+from frappe.tests.utils import FrappeTestCase
+
+from ferum_customs import api
+
+
+class TestAPIIntegration(FrappeTestCase):
+    def test_bot_create_and_get_service_request(self, frappe_site):
+        name = api.bot_create_service_request("From bot", description="demo")
+        self.assertTrue(frappe.db.exists("Service Request", name))
+        results = api.bot_get_service_requests()
+        self.assertIn(name, [r["name"] for r in results])

--- a/tests/unit/test_api_invoice.py
+++ b/tests/unit/test_api_invoice.py
@@ -1,0 +1,38 @@
+import importlib
+from types import SimpleNamespace
+
+
+def test_create_invoice_from_report(frappe_stub):
+    api = importlib.import_module("ferum_customs.api")
+
+    sr_doc = SimpleNamespace(
+        get=lambda key, default=None: {
+            "customer": "Cust1",
+            "work_items": [
+                {"description": "Work", "quantity": 2, "unit_price": 50, "amount": 100}
+            ],
+        }.get(key, default),
+        calculate_totals=lambda: None,
+    )
+
+    items = []
+    invoice_doc = SimpleNamespace(
+        name="INV001",
+        append=lambda field, item: items.append(item),
+        insert=lambda ignore_permissions=True: None,
+    )
+
+    def get_doc(doctype, name=None):
+        if isinstance(doctype, dict):
+            return invoice_doc
+        if doctype == "Service Report":
+            assert name == "SR1"
+            return sr_doc
+        raise AssertionError("unexpected doctype")
+
+    frappe_stub.get_doc = get_doc
+    frappe_stub.db.exists = lambda *a, **k: None
+
+    result = api.create_invoice_from_report("SR1")
+    assert result == "INV001"
+    assert items and items[0]["description"] == "Work"

--- a/tests/unit/test_service_object_hook.py
+++ b/tests/unit/test_service_object_hook.py
@@ -1,0 +1,21 @@
+import importlib
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_validate_duplicate_serial(frappe_stub):
+    frappe_stub.db.exists = lambda doctype, filters: "SO-0002"
+    captured = {}
+    def throw(msg, exc=None, *a, **k):
+        captured['msg'] = msg
+        raise frappe_stub.ValidationError(msg)
+    frappe_stub.throw = throw
+
+    hooks = importlib.import_module("ferum_customs.custom_logic.service_object_hooks")
+
+    doc = SimpleNamespace(serial_no=" SN123 ", name="SO-0001", get=lambda k, d=None: getattr(doc, k, d))
+    with pytest.raises(frappe_stub.ValidationError):
+        hooks.validate(doc)
+    assert "Серийный номер" in captured['msg']


### PR DESCRIPTION
## Summary
- add fixture to mock Frappe for unit tests
- cover hooks and API helpers with unit tests
- add integration and e2e tests that require real Frappe
- install the app during local setup script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c32ce7c108328bb3971974335df95