### PR TITLE
Fix pip install step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: docker compose -f docker-compose.test.yml up -d mariadb redis
 
       - name: Install test dependencies
-        run: docker compose -f docker-compose.test.yml run --rm frappe pip install -q pytest pytest-cov
+        run: docker compose -f docker-compose.test.yml run --rm frappe pip install pytest pytest-cov
 
       - name: Run Frappe tests
         run: docker compose -f docker-compose.test.yml run --rm frappe pytest --app ferum_customs -vs --cov


### PR DESCRIPTION
## Summary
- fix `Install test dependencies` step in CI workflow

## Testing
- `pre-commit` *(fails: network issues installing hooks)*

------
https://chatgpt.com/codex/tasks/task_e_685c3973ea1c8328801ba9f7506bb9d8