### PR TITLE
Add Codex CLI setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ docker compose up -d --build
 ```
 
 The helper script `scripts/setup_environment.sh` can bootstrap a development bench in Docker and install the app automatically.
+The helper script `scripts/setup_codex.sh` installs Docker and builds the Codex CLI image for local use.
 
 Add `ferum_customs` to `apps.txt` (or `apps.json`) if you build custom images.
 

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { printf "\e[1;34m>>> %s\e[0m\n" "$*"; }
+
+# Allow overriding HTTP(S)_PROXY from environment
+export HTTP_PROXY=${HTTP_PROXY:-""}
+export HTTPS_PROXY=${HTTPS_PROXY:-""}
+
+# 0. Проверка root/не-root
+if [[ $EUID -eq 0 ]]; then
+  echo "❌ Запускать скрипт от root не нужно. Запустите под обычным пользователем."
+  exit 1
+fi
+
+log "Обновление списка пакетов..."
+sudo apt-get update -y
+
+log "Установка Docker и вспомогательных пакетов..."
+sudo apt-get install -y docker.io git ca-certificates curl gnupg
+sudo systemctl enable --now docker
+
+log "Добавление пользователя $USER в группу docker..."
+if ! groups $USER | grep -q '\bdocker\b'; then
+  sudo usermod -aG docker "$USER"
+  NEW_GRP_NOTE=true
+fi
+
+log "Проверка: существует ли образ codex?"
+if ! docker images -q codex >/dev/null 2>&1; then
+  log "Сборка Docker-образа 'codex'..."
+  if [[ ! -d "$HOME/codex" ]]; then
+    git clone https://github.com/openai/codex.git "$HOME/codex"
+  else
+    log "Репозиторий уже существует, делаю git pull..."
+    git -C "$HOME/codex" pull --ff-only
+  fi
+  cd "$HOME/codex/codex-cli"
+  sudo docker build -t codex .
+  cd -
+else
+  log "Образ 'codex' уже есть — пропускаю сборку."
+fi
+
+log "Отключение firewall-ограничений в Codex контейнере..."
+RUN_IN_CONTAINER_PATH=$(sudo find /usr -type f -name run_in_container.sh 2>/dev/null | head -n1 || true)
+if [[ -n "$RUN_IN_CONTAINER_PATH" ]]; then
+  sudo sed -i '/init_firewall.sh/s/^/#/' "$RUN_IN_CONTAINER_PATH"
+  log "Изменён файл $RUN_IN_CONTAINER_PATH: сетевые ограничения отключены."
+else
+  echo "⚠️  Не найден run_in_container.sh — возможно Codex CLI ещё не установлен."
+fi
+
+log "Очистка apt кеша..."
+sudo apt-get clean
+
+log "Готово ✅"
+if [[ "${NEW_GRP_NOTE:-false}" == true ]]; then
+  echo "ℹ️  Выйдите из системы и войдите снова (или запустите 'newgrp docker'), чтобы новые групповые права применились."
+fi


### PR DESCRIPTION
## Summary
- provide a helper to install Codex CLI and disable container firewall
- mention the new script in the README

## Testing
- `pre-commit run --files scripts/setup_codex.sh README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d27e3712c8328a0efbf5fe0fcc6f7