### PR TITLE
Add quick Docker setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ docker compose up -d --build
 
 The helper script `scripts/setup_environment.sh` can bootstrap a development bench in Docker and install the app automatically.
 The helper script `scripts/setup_codex.sh` installs Docker and builds the Codex CLI image for local use.
+The lightweight `scripts/quick_setup.sh` script simply runs `docker compose` with the provided configuration.
 
 Add `ferum_customs` to `apps.txt` (or `apps.json`) if you build custom images.
 

--- a/scripts/quick_setup.sh
+++ b/scripts/quick_setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Quick start helper for local development
+set -euo pipefail
+
+DC="docker compose"
+
+if ! command -v docker >/dev/null; then
+    echo "Docker is required but not installed." >&2
+    exit 1
+fi
+
+if ! ${DC} version >/dev/null 2>&1; then
+    DC="docker-compose"
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( dirname "$SCRIPT_DIR" )"
+cd "$ROOT_DIR"
+
+if [ ! -f .env ]; then
+    echo ".env not found, creating from .env.example"
+    cp .env.example .env
+fi
+
+${DC} up -d --build


### PR DESCRIPTION
## Summary
- add `scripts/quick_setup.sh` for simple Docker startup
- document quick setup script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e50f0b7508328a8de2147aea86274