### PR TITLE
Run ruff formatter

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,36 +17,36 @@ class DummyLog:
 
 @pytest.fixture
 def frappe_stub(monkeypatch, tmp_path):
-    frappe = types.SimpleNamespace()
-    frappe.db = types.SimpleNamespace(
-        exists=lambda *a, **k: None,
-        get_value=lambda *a, **k: None,
-    )
+	frappe = types.SimpleNamespace()
+	frappe.db = types.SimpleNamespace(
+		exists=lambda *a, **k: None,
+		get_value=lambda *a, **k: None,
+	)
 
-    class ValidationError(Exception):
-        pass
+	class ValidationError(Exception):
+		pass
 
-    class PermissionError(Exception):
-        pass
+	class PermissionError(Exception):
+		pass
 
-    frappe.ValidationError = ValidationError
-    frappe.PermissionError = PermissionError
-    exc_mod = types.ModuleType("frappe.exceptions")
-    exc_mod.PermissionError = PermissionError
-    sys.modules["frappe.exceptions"] = exc_mod
-    frappe.DoesNotExistError = Exception
-    frappe.throw = lambda msg, exc=None, *a, **k: (_ for _ in ()).throw(
-        exc(msg) if exc else ValidationError(msg)
-    )
-    frappe._ = lambda s: s
-    frappe.logger = lambda name=None: DummyLog()
-    frappe.utils = types.SimpleNamespace(now=lambda: "now")
-    frappe.get_site_path = lambda *parts: str(tmp_path.joinpath(*parts))
-    frappe.session = types.SimpleNamespace(user="test-user")
-    frappe.whitelist = lambda *args, **kwargs: (lambda f: f)
-    frappe.get_doc = lambda *a, **k: None
-    frappe.get_all = lambda *a, **k: []
-    frappe.has_permission = lambda *a, **k: True
-    sys.modules["frappe"] = frappe
-    yield frappe
-    sys.modules.pop("frappe", None)
+	frappe.ValidationError = ValidationError
+	frappe.PermissionError = PermissionError
+	exc_mod = types.ModuleType("frappe.exceptions")
+	exc_mod.PermissionError = PermissionError
+	sys.modules["frappe.exceptions"] = exc_mod
+	frappe.DoesNotExistError = Exception
+	frappe.throw = lambda msg, exc=None, *a, **k: (_ for _ in ()).throw(
+		exc(msg) if exc else ValidationError(msg)
+	)
+	frappe._ = lambda s: s
+	frappe.logger = lambda name=None: DummyLog()
+	frappe.utils = types.SimpleNamespace(now=lambda: "now")
+	frappe.get_site_path = lambda *parts: str(tmp_path.joinpath(*parts))
+	frappe.session = types.SimpleNamespace(user="test-user")
+	frappe.whitelist = lambda *args, **kwargs: (lambda f: f)
+	frappe.get_doc = lambda *a, **k: None
+	frappe.get_all = lambda *a, **k: []
+	frappe.has_permission = lambda *a, **k: True
+	sys.modules["frappe"] = frappe
+	yield frappe
+	sys.modules.pop("frappe", None)

--- a/tests/unit/test_file_attachment_utils.py
+++ b/tests/unit/test_file_attachment_utils.py
@@ -1,29 +1,29 @@
 import importlib
+
 import pytest
 
 
 def get_utils():
-    return importlib.import_module("ferum_customs.custom_logic.file_attachment_utils")
+	return importlib.import_module("ferum_customs.custom_logic.file_attachment_utils")
 
 
 def test_resolve_attachment_public(frappe_stub, tmp_path):
-    (tmp_path / "public" / "files").mkdir(parents=True)
-    utils = importlib.reload(get_utils())
-    path, base, name = utils._resolve_attachment_path("/files/test.txt", False)
-    assert path == (tmp_path / "public" / "files" / "test.txt").resolve()
-    assert base == (tmp_path / "public" / "files").resolve()
-    assert name == "test.txt"
+	(tmp_path / "public" / "files").mkdir(parents=True)
+	utils = importlib.reload(get_utils())
+	path, base, name = utils._resolve_attachment_path("/files/test.txt", False)
+	assert path == (tmp_path / "public" / "files" / "test.txt").resolve()
+	assert base == (tmp_path / "public" / "files").resolve()
+	assert name == "test.txt"
 
 
 def test_resolve_attachment_invalid_prefix(frappe_stub):
-    utils = importlib.reload(get_utils())
-    with pytest.raises(frappe_stub.ValidationError):
-        utils._resolve_attachment_path("/bad/test.txt", False)
+	utils = importlib.reload(get_utils())
+	with pytest.raises(frappe_stub.ValidationError):
+		utils._resolve_attachment_path("/bad/test.txt", False)
 
 
 def test_resolve_attachment_traversal(frappe_stub, tmp_path):
-    (tmp_path / "public" / "files").mkdir(parents=True)
-    utils = importlib.reload(get_utils())
-    with pytest.raises(frappe_stub.PermissionError):
-        utils._resolve_attachment_path("/files/../secret.txt", False)
-
+	(tmp_path / "public" / "files").mkdir(parents=True)
+	utils = importlib.reload(get_utils())
+	with pytest.raises(frappe_stub.PermissionError):
+		utils._resolve_attachment_path("/files/../secret.txt", False)


### PR DESCRIPTION
## Summary
- run `ruff` formatting over the tests

## Testing
- `ruff check tests/conftest.py tests/unit/test_file_attachment_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_e_685e746a2b9083288da973b3132f90ba