### PR TITLE
Fix FSM e2e test

### DIFF
--- a/telegram_bot/bot_service.py
+++ b/telegram_bot/bot_service.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 import os
 
 from aiogram import Bot, Dispatcher
+from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.fsm.storage.base import BaseStorage
 from aiogram.fsm.storage.memory import MemoryStorage
+from aiogram.types import Message
 from fastapi import FastAPI
 
 
@@ -48,28 +50,36 @@ app = FastAPI(title="Ferum Bot Service")
 
 
 def _create_dispatcher(
-        bot: Bot | None = None,
-        storage: BaseStorage | None = None,
+	bot: Bot | None = None,
+	storage: BaseStorage | None = None,
 ) -> Dispatcher:
-        """Instantiate dispatcher with in‑memory storage."""
+	"""Instantiate dispatcher with in‑memory storage."""
 
-        if bot is None:
-                token = os.getenv("TELEGRAM_BOT_TOKEN", "0:TOKEN")
-                bot = Bot(token)
-        if storage is None:
-                storage = MemoryStorage()
-        return Dispatcher(storage=storage, bot=bot)
+	if bot is None:
+		token = os.getenv("TELEGRAM_BOT_TOKEN", "0:TOKEN")
+		bot = Bot(token)
+	if storage is None:
+		storage = MemoryStorage()
+	return Dispatcher(storage=storage, bot=bot)
 
 
-def get_dispatcher(
-        *, bot: Bot | None = None, storage: BaseStorage | None = None
-) -> Dispatcher:
-        """Return a dispatcher instance for external usage (e.g. tests)."""
+def get_dispatcher(*, bot: Bot | None = None, storage: BaseStorage | None = None) -> Dispatcher:
+	"""Return a dispatcher instance for external usage (e.g. tests)."""
 
-        return _create_dispatcher(bot=bot, storage=storage)
+	return _create_dispatcher(bot=bot, storage=storage)
 
 
 dispatcher = _create_dispatcher()
+
+
+async def start_handler(bot: Bot, message: Message, state: FSMContext) -> None:
+	"""Simple `/start` command handler.
+
+	It sets the incident FSM to the first state. Network calls are omitted
+	for testing purposes.
+	"""
+
+	await state.set_state(IncidentStates.waiting_object)
 
 
 @app.on_event("startup")
@@ -88,10 +98,11 @@ async def shutdown_event() -> None:  # pragma: no cover - example implementation
 
 
 __all__ = [
-        "app",
-        "dispatcher",
-        "get_dispatcher",
-        "IncidentStates",
-        "TaskStates",
-        "PhotoStates",
+	"app",
+	"dispatcher",
+	"get_dispatcher",
+	"start_handler",
+	"IncidentStates",
+	"TaskStates",
+	"PhotoStates",
 ]

--- a/tests/e2e/test_fsm_conversation.py
+++ b/tests/e2e/test_fsm_conversation.py
@@ -1,53 +1,57 @@
-
 import pytest
 
 pytest.importorskip("aiogram")
 
+from datetime import datetime, timezone
+
 from aiogram import Bot, Dispatcher
 from aiogram.enums import ChatType
 from aiogram.fsm.context import FSMContext
-from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.fsm.storage.base import StorageKey
+from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import Message
-from datetime import datetime, timezone
 from aiogram.utils.token import TokenValidationError
 
 try:
-	from telegram_bot.bot_service import IncidentStates, get_dispatcher
+	from telegram_bot.bot_service import (
+		IncidentStates,
+		get_dispatcher,
+		start_handler,
+	)
 except Exception:
 	pytest.skip("bot service init failed", allow_module_level=True)
 
 
-def test_fsm_start_handler():
-	async def _run():
-		# Подготовка мока
-		try:
-			bot = Bot(token="12345:TOKEN", parse_mode="HTML")
-		except TokenValidationError:
-			pytest.skip("invalid token")
-		storage = MemoryStorage()
-		dispatcher: Dispatcher = get_dispatcher(bot=bot, storage=storage)
+@pytest.mark.asyncio
+async def test_fsm_start_handler():
+	"""`/start` command moves FSM to the first state."""
 
-		# Эмуляция входящего сообщения
-		_message = Message(
+	# Подготовка мока
+	try:
+		bot = Bot(token="12345:TOKEN", parse_mode="HTML")
+	except TokenValidationError:
+		pytest.skip("invalid token")
+	storage = MemoryStorage()
+	dispatcher: Dispatcher = get_dispatcher(bot=bot, storage=storage)
+
+	# Эмуляция входящего сообщения
+	message = Message(
 		message_id=1,
 		date=datetime.now(timezone.utc),
 		chat={"id": 123, "type": ChatType.PRIVATE},
 		from_user={"id": 123, "is_bot": False, "first_name": "Test"},
 		text="/start",
-		)
+	)
 
-		# Эмуляция FSM context
-		key = StorageKey(bot_id=0, chat_id=123, user_id=123)
-		_fsm_context = FSMContext(storage=storage, key=key)
+	# Эмуляция FSM context
+	key = StorageKey(bot_id=0, chat_id=123, user_id=123)
+	fsm_context = FSMContext(storage=storage, key=key)
 
-		# Эмуляция вызова хендлера (только если у тебя он явно вызывается)
-		# await start_handler(message, state=fsm_context)
+	# Вызов хендлера
+	await start_handler(bot, message=message, state=fsm_context)
 
-		assert dispatcher
-
-	import asyncio
-	asyncio.run(_run())
+	assert await fsm_context.get_state() == IncidentStates.waiting_object.state
+	assert dispatcher
 
 
 def test_fsm_state_values():


### PR DESCRIPTION
## Summary
- implement minimal start_handler for the Telegram bot
- test the FSM start handler in e2e tests
- format files with ruff

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e7ce257a88328ba41e9982602b802