### PR TITLE
Fix FSM imports and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4
     hooks:
       - id: ruff

--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ You can also run the whole suite with `pytest`:
 pytest
 ```
 
+### Local linting
+
+Install development dependencies and run pre-commit hooks:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit run --all-files
+```
+
 ## CI
 
 GitHub Actions start containers defined in `docker-compose.test.yml` and run unit tests. The same stack can be started locally with:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest>=8,<9
 pytest-cov  # optional, for coverage
+pytest-asyncio>=0.23
 ruff
 pre-commit
 

--- a/telegram_bot/fsm/__init__.py
+++ b/telegram_bot/fsm/__init__.py
@@ -1,0 +1,5 @@
+"""Finite state machine definitions for the Telegram bot."""
+
+from .states import SomeState
+
+__all__ = ["SomeState"]

--- a/telegram_bot/fsm/states.py
+++ b/telegram_bot/fsm/states.py
@@ -1,0 +1,7 @@
+from aiogram.fsm.state import State, StatesGroup
+
+
+class SomeState(StatesGroup):
+    """Example FSM state used in tests."""
+
+    waiting = State()

--- a/telegram_bot/handlers.py
+++ b/telegram_bot/handlers.py
@@ -1,0 +1,5 @@
+"""Handlers for the Telegram bot."""
+
+from .bot_service import IncidentStates, start_handler
+
+__all__ = ["start_handler", "IncidentStates"]

--- a/tests/e2e/test_fsm_conversation.py
+++ b/tests/e2e/test_fsm_conversation.py
@@ -8,7 +8,7 @@ from aiogram.fsm.storage.base import StorageKey
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import Message, Update
 
-from telegram_bot.bot_service import IncidentStates, start_handler
+from telegram_bot.handlers import IncidentStates, start_handler
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_fsm.py
+++ b/tests/unit/test_fsm.py
@@ -1,5 +1,8 @@
 import pytest
 
+from telegram_bot.fsm.states import SomeState
+
 
 def test_dummy_fsm():
-    assert True, "FSM тест-заглушка"
+    # Ensure FSM states are accessible
+    assert hasattr(SomeState, "waiting")


### PR DESCRIPTION
## Summary
- expose Telegram bot handler and FSM state from new modules
- ensure pre-commit uses correct ruff repo
- add pytest-asyncio to dev requirements
- adjust FSM tests to new import paths
- document running pre-commit and pytest locally

## Testing
- `pre-commit run --files telegram_bot/handlers.py telegram_bot/fsm/states.py tests/e2e/test_fsm_conversation.py tests/unit/test_fsm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e82a739448328a30217ea49777d79