### PR TITLE
Improve typing hygiene and scripts

### DIFF
--- a/ferum_customs/bench_commands/run_tests.py
+++ b/ferum_customs/bench_commands/run_tests.py
@@ -4,15 +4,15 @@ import click
 import pytest
 
 
-@click.command("run-tests")  # type: ignore[misc]
-@click.option("--site", required=True, help="Site name on which to run tests")  # type: ignore[misc]
-@click.option("--app", required=True, help="App name to test")  # type: ignore[misc]
+@click.command("run-tests")
+@click.option("--site", required=True, help="Site name on which to run tests")
+@click.option("--app", required=True, help="App name to test")
 @click.option(
     "--test",
     "test_path",
     default="tests/unit",
     help="Test path relative to app, e.g., tests/unit",
-)  # type: ignore[misc]
+)
 def run_tests(site: str, app: str, test_path: str) -> None:
     """Run pytest tests for the specified app."""
     # Ensure SITE_NAME is set for any fixtures or configurations

--- a/ferum_customs/config/settings.py
+++ b/ferum_customs/config/settings.py
@@ -1,13 +1,13 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):  # type: ignore[misc]
+class Settings(BaseSettings):
     """
     Application settings loaded from environment variables.
     """
 
     # Telegram Bot API token
-    telegram_bot_token: str
+    telegram_bot_token: str = ""
 
     # Frappe/ERPNext settings
     site_name: str | None = None

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -8,7 +8,7 @@ def main() -> None:
     settings = Settings(telegram_bot_token="")
     fields = settings.model_fields
     lines = ["# Generated .env.example"]
-    for name, field in fields.items():
+    for name, _ in fields.items():
         key = name.upper()
         default = getattr(settings, name, "")
         value = default if default is not None else ""

--- a/telegram_bot/bot_service.py
+++ b/telegram_bot/bot_service.py
@@ -24,7 +24,7 @@ from fastapi import FastAPI
 from ferum_customs.config.settings import settings
 
 
-class IncidentStates(StatesGroup):  # type: ignore[misc]
+class IncidentStates(StatesGroup):
     """Conversation flow for incident reporting."""
 
     waiting_object = State()
@@ -32,14 +32,14 @@ class IncidentStates(StatesGroup):  # type: ignore[misc]
     waiting_photo = State()
 
 
-class TaskStates(StatesGroup):  # type: ignore[misc]
+class TaskStates(StatesGroup):
     """Conversation flow for task creation."""
 
     waiting_title = State()
     waiting_details = State()
 
 
-class PhotoStates(StatesGroup):  # type: ignore[misc]
+class PhotoStates(StatesGroup):
     """Standalone photo upload flow."""
 
     waiting_photo = State()
@@ -83,7 +83,7 @@ async def start_handler(bot: Bot, message: Message, state: FSMContext) -> None:
     await state.set_state(IncidentStates.waiting_object)
 
 
-@app.on_event("startup")  # type: ignore[misc]
+@app.on_event("startup")
 async def startup_event() -> None:  # pragma: no cover - example implementation
     """Hook that runs on service startup."""
 
@@ -91,7 +91,7 @@ async def startup_event() -> None:  # pragma: no cover - example implementation
     pass
 
 
-@app.on_event("shutdown")  # type: ignore[misc]
+@app.on_event("shutdown")
 async def shutdown_event() -> None:  # pragma: no cover - example implementation
     """Hook that runs on service shutdown."""
 

--- a/telegram_bot/fsm/states.py
+++ b/telegram_bot/fsm/states.py
@@ -1,7 +1,7 @@
 from aiogram.fsm.state import State, StatesGroup
 
 
-class SomeState(StatesGroup):  # type: ignore[misc]
+class SomeState(StatesGroup):
     """Example FSM state used in tests."""
 
     waiting = State()


### PR DESCRIPTION
## Summary
- clean up unused `type: ignore` comments
- make env generator script ruff-clean
- set default for `telegram_bot_token` in settings
- drop ignores from bench commands

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9e5c2dcc8328bb358cf18f60df43