### PR TITLE
Fix mypy config and annotate tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,6 +118,7 @@ repos:
           - ferum_customs/ferum_customs
         additional_dependencies:
           - fastapi==0.115.14
+          - pydantic-settings
         exclude: ^\.venv_dev/
 
   - repo: local

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,8 +1,11 @@
+from pathlib import Path
+
+from _pytest.monkeypatch import MonkeyPatch
 
 from ferum_customs.config.settings import Settings
 
 
-def test_settings_env_file(tmp_path, monkeypatch):
+def test_settings_env_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Проверка загрузки настроек из .env и игнорирование лишних переменных."""
     env_content = (
         "TELEGRAM_BOT_TOKEN=token123\n" "SITE_NAME=mysite\n" "EXTRA_VAR=ignored"


### PR DESCRIPTION
## Summary
- add missing dependency to mypy hook
- provide type hints for settings test

## Testing
- `pre-commit run --files ferum_customs/config/settings.py tests/unit/test_settings.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eed18e4288328a910bd88e3b8f88e