### PR TITLE
Add OpenAI helper function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ ADMIN_PASSWORD=changeme
 FRAPPE_ADMIN_PASSWORD=changeme
 # Frappe settings
 FRAPPE_URL=
+OPENAI_API_KEY=
 
 # Docker Compose variables (for local development)
 BENCH_TAG=v5.25.4            # Frappe/Bench version tag

--- a/ferum_customs/bench_commands/run_tests.py
+++ b/ferum_customs/bench_commands/run_tests.py
@@ -4,10 +4,10 @@ import click
 import pytest
 
 
-@click.command("run-tests")
-@click.option("--site", required=True, help="Site name on which to run tests")
-@click.option("--app", required=True, help="App name to test")
-@click.option(
+@click.command("run-tests")  # type: ignore[misc]
+@click.option("--site", required=True, help="Site name on which to run tests")  # type: ignore[misc]
+@click.option("--app", required=True, help="App name to test")  # type: ignore[misc]
+@click.option(  # type: ignore[misc]
     "--test",
     "test_path",
     default="tests/unit",

--- a/ferum_customs/config/settings.py
+++ b/ferum_customs/config/settings.py
@@ -16,6 +16,9 @@ class Settings(BaseSettings):
     # URL for Frappe API (optional override)
     frappe_url: str | None = None
 
+    # OpenAI API key for optional integrations
+    openai_api_key: str | None = None
+
     model_config = SettingsConfigDict(
         env_file=[".env", ".env.example"],
         env_file_encoding="utf-8",

--- a/ferum_customs/openai_utils.py
+++ b/ferum_customs/openai_utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import openai
+
+from ferum_customs.config.settings import settings
+
+openai.api_key = settings.openai_api_key or openai.api_key
+
+
+def complete_code(prompt: str) -> str:
+    """Return a Python code completion for the given fragment."""
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Ты опытный программист. Пиши код аккуратно, только на языке Python."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Заверши следующий фрагмент кода:\n\n{prompt}\n\n# Допиши продолжение кода:",
+            },
+        ],
+        temperature=0.2,
+        max_tokens=400,
+        stop=["\n\n", "# Конец"],
+        stream=False,
+    )
+    content = response["choices"][0]["message"]["content"]
+    return str(content).strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "requests-oauthlib==2.0.0",
     "fastapi==0.115.14",
     "aiogram==3.5.0",
+    "openai>=1.0.0",
     # "frappe~=15.0.0" # Installed and managed by bench.
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv>=1.0.0
 requests-oauthlib==2.0.0  # satisfies frappe 16.x
 fastapi==0.115.14
 aiogram==3.5.0
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- provide `openai_utils.complete_code` helper
- configure OpenAI API key via settings
- document OPENAI_API_KEY in `.env.example`
- depend on `openai`
- silence mypy on click decorators

## Testing
- `pre-commit run --files .env.example ferum_customs/openai_utils.py ferum_customs/config/settings.py pyproject.toml requirements.txt ferum_customs/bench_commands/run_tests.py`
- `pytest -q` *(fails: async tests require pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_688b9aea16508328a4ecddc461b3d13e