### PR TITLE
Fix progress context manager

### DIFF
--- a/scripts/gpt_full_review.py
+++ b/scripts/gpt_full_review.py
@@ -427,15 +427,14 @@ async def main(cfg: argparse.Namespace) -> None:
             console.print(
                 f"[cyan]▶ {len(cached_results)} файлов из кэша. Начинаю GPT‑ревью {len(files_to_review)} новых/изменённых файлов…[/cyan]"
             )
-            progress = Progress(
+            with Progress(
                 SpinnerColumn(),
                 TextColumn("{task.description}"),
                 BarColumn(),
                 "[progress.percentage]{task.percentage:>3.0f}%",
                 TimeElapsedColumn(),
                 console=console,
-            )
-            with progress:
+            ) as progress:
                 task_id = progress.add_task(
                     "[green]Анализ…", total=len(files_to_review)
                 )


### PR DESCRIPTION
## Summary
- use the standard context manager for `Progress`

## Testing
- `pre-commit run --files scripts/gpt_full_review.py`
- `pytest -k gpt_full_review -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688c4e339a788328b6f0834ced362789