### PR TITLE
chore: apply lint auto-fixes

### DIFF
--- a/ferum_customs/api/__init__.py
+++ b/ferum_customs/api/__init__.py
@@ -1,12 +1,14 @@
-from typing import Any, List, Dict, Optional
+from typing import Any
 
 import frappe
 from frappe import _, whitelist
 from frappe.exceptions import PermissionError
+
 from ferum_customs.constants import SERVICE_REQUEST_STATUSES, STATUS_OTKRYTA
 
+
 @frappe.whitelist()
-def validate_service_request(docname: str) -> Optional[Dict[str, Any]]:
+def validate_service_request(docname: str) -> dict[str, Any] | None:
     """Return the service request document as a dict after permission check."""
     if not frappe.has_permission("Service Request", "read"):
         frappe.throw(_("Not permitted"), PermissionError)
@@ -34,7 +36,7 @@ def cancel_service_request(docname: str) -> None:
 
 
 @frappe.whitelist()
-def validate_service_report(docname: str) -> Optional[Dict[str, Any]]:
+def validate_service_report(docname: str) -> dict[str, Any] | None:
     """Return the service report document as a dict after permission check."""
     if not frappe.has_permission("Service Report", "read"):
         frappe.throw(_("Not permitted"), PermissionError)
@@ -109,8 +111,8 @@ def create_invoice_from_report(service_report: str) -> str:
 @frappe.whitelist()
 def bot_create_service_request(
     subject: str,
-    customer: Optional[str] = None,
-    description: Optional[str] = None,
+    customer: str | None = None,
+    description: str | None = None,
 ) -> str:
     """Create a Service Request document on behalf of the Telegram bot."""
     doc = frappe.get_doc(
@@ -153,7 +155,7 @@ def bot_upload_attachment(docname: str, file_url: str, attachment_type: str) -> 
 
 
 @frappe.whitelist()
-def bot_get_service_requests(status: Optional[str] = None) -> List[Dict[str, Any]]:
+def bot_get_service_requests(status: str | None = None) -> list[dict[str, Any]]:
     """Return a list of Service Requests filtered by status."""
     filters = {"status": status} if status else {}
     return frappe.get_all(

--- a/ferum_customs/bench_commands/run_tests.py
+++ b/ferum_customs/bench_commands/run_tests.py
@@ -1,16 +1,18 @@
+import logging
 import os
 import sys
+from typing import Optional
+
 import click
 import pytest
-import logging
-from typing import Optional
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 
+
 @click.command()
-@click.argument('app', type=str)
-@click.argument('test_path', type=str)
+@click.argument("app", type=str)
+@click.argument("test_path", type=str)
 def run_tests(app: str, test_path: str) -> None:
     """
     Run tests for the specified app at the given test path.
@@ -20,15 +22,17 @@ def run_tests(app: str, test_path: str) -> None:
     :raises click.ClickException: If there is a directory traversal attempt or test execution failure.
     """
     # Directory Traversal Protection
-    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     app_path = os.path.abspath(os.path.join(base_dir, app))
     test_path = os.path.abspath(os.path.join(base_dir, test_path))
 
     if not app_path.startswith(base_dir) or not test_path.startswith(base_dir):
-        raise click.ClickException("Invalid path: potential directory traversal detected.")
+        raise click.ClickException(
+            "Invalid path: potential directory traversal detected."
+        )
 
     # Environment Variable Handling
-    original_site_name: Optional[str] = os.environ.get("SITE_NAME")
+    original_site_name: str | None = os.environ.get("SITE_NAME")
     os.environ["SITE_NAME"] = app
 
     try:
@@ -47,6 +51,7 @@ def run_tests(app: str, test_path: str) -> None:
         else:
             os.environ.pop("SITE_NAME", None)
 
+
 def run_pytest(test_path: str) -> int:
     """Run pytest on the specified test path.
 
@@ -60,5 +65,6 @@ def run_pytest(test_path: str) -> int:
         logging.error(f"An error occurred while running tests: {e}")
         raise click.ClickException(f"An error occurred while running tests: {e}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_tests()

--- a/ferum_customs/config/settings.py
+++ b/ferum_customs/config/settings.py
@@ -1,5 +1,7 @@
-from pydantic import BaseSettings, SecretStr
 from typing import Optional
+
+from pydantic import BaseSettings, SecretStr
+
 
 class Settings(BaseSettings):
     """
@@ -10,18 +12,19 @@ class Settings(BaseSettings):
     telegram_bot_token: SecretStr
 
     # Frappe/ERPNext settings
-    site_name: Optional[str] = None  # Name of the Frappe site
-    admin_password: Optional[SecretStr] = None  # Admin password for Frappe site
+    site_name: str | None = None  # Name of the Frappe site
+    admin_password: SecretStr | None = None  # Admin password for Frappe site
 
     # URL for Frappe API (optional override)
-    frappe_url: Optional[str] = None  # Base URL for Frappe API
+    frappe_url: str | None = None  # Base URL for Frappe API
 
     # OpenAI API key for optional integrations
-    openai_api_key: Optional[SecretStr] = None  # API key for OpenAI integrations
+    openai_api_key: SecretStr | None = None  # API key for OpenAI integrations
 
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
         extra = "ignore"
+
 
 settings = Settings()

--- a/ferum_customs/constants.py
+++ b/ferum_customs/constants.py
@@ -16,7 +16,6 @@
 - Используйте ROLE_ADMINISTRATOR для проверки прав доступа пользователя.
 """
 
-from typing import List
 
 # --- Статусы Заявок на обслуживание (service_request) ---
 STATUS_OPEN: str = "Open"
@@ -33,7 +32,7 @@ STATUS_VYPOLNENA: str = "Выполнена"
 STATUS_ZAKRYTA: str = "Закрыта"
 STATUS_OTMENENA: str = "Отменена"
 
-SERVICE_REQUEST_STATUSES: List[str] = [
+SERVICE_REQUEST_STATUSES: list[str] = [
     STATUS_OTKRYTA,
     STATUS_V_RABOTE,
     STATUS_VYPOLNENA,

--- a/ferum_customs/custom_logic/file_attachment_utils.py
+++ b/ferum_customs/custom_logic/file_attachment_utils.py
@@ -37,7 +37,7 @@ def _resolve_attachment_path(file_url: str, is_private: bool) -> tuple[Path, Pat
         )
         raise frappe.ValidationError(msg.format(file_url))
 
-    relative = file_url[len(prefix):]
+    relative = file_url[len(prefix) :]
     safe_name = os.path.basename(relative)
     if safe_name != relative or not safe_name or safe_name in (".", ".."):
         logger.error(
@@ -46,9 +46,7 @@ def _resolve_attachment_path(file_url: str, is_private: bool) -> tuple[Path, Pat
             relative,
             safe_name,
         )
-        raise frappe.PermissionError(
-            _("Invalid file name or path traversal attempt.")
-        )
+        raise frappe.PermissionError(_("Invalid file name or path traversal attempt."))
 
     base_dir = Path(frappe.get_site_path(base_folder, "files")).resolve(strict=True)
     file_path = (base_dir / safe_name).resolve()
@@ -154,7 +152,7 @@ def delete_attachment_file_from_filesystem(
         )
 
 
-def on_custom_attachment_trash(doc: FrappeDocument, method: Optional[str] = None) -> None:
+def on_custom_attachment_trash(doc: FrappeDocument, method: str | None = None) -> None:
     """
     Called when a CustomAttachment record is deleted (on_trash).
     Deletes the associated physical file and, if present, the File record.

--- a/ferum_customs/custom_logic/payroll_entry_hooks.py
+++ b/ferum_customs/custom_logic/payroll_entry_hooks.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
         PayrollEntryCustom,
     )
 
-def validate(doc: PayrollEntryCustom, method: Optional[str] = None) -> None:
+
+def validate(doc: PayrollEntryCustom, method: str | None = None) -> None:
     """
     Проверяет корректность дат периода. Дата окончания не может быть раньше даты начала.
 
@@ -35,7 +36,8 @@ def validate(doc: PayrollEntryCustom, method: Optional[str] = None) -> None:
                 )
             )
 
-def before_save(doc: PayrollEntryCustom, method: Optional[str] = None) -> None:
+
+def before_save(doc: PayrollEntryCustom, method: str | None = None) -> None:
     """Calculate ``total_payable`` before saving."""
 
     total_bonus = 0.0
@@ -66,5 +68,5 @@ def before_save(doc: PayrollEntryCustom, method: Optional[str] = None) -> None:
     if doc.total_payable is None:
         doc.total_payable = 0.0
 
-    if isinstance(doc.total_payable, (float, int)):
+    if isinstance(doc.total_payable, float | int):
         doc.total_payable = round(doc.total_payable, 2)

--- a/ferum_customs/custom_logic/service_object_hooks.py
+++ b/ferum_customs/custom_logic/service_object_hooks.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import frappe
 from frappe import _  # For translation
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from ferum_customs.ferum_customs.doctype.service_object.service_object import (
         ServiceObject,
     )
+
 
 def validate(doc: ServiceObject) -> None:
     """
@@ -27,8 +28,10 @@ def validate(doc: ServiceObject) -> None:
     if doc.get("serial_no"):
         serial_no_cleaned = doc.serial_no.strip()
         if not serial_no_cleaned:
-            frappe.throw(_("Serial number cannot be empty."), title=_("Validation Error"))
-        
+            frappe.throw(
+                _("Serial number cannot be empty."), title=_("Validation Error")
+            )
+
         filters = {
             "serial_no": serial_no_cleaned,
             "name": ["!=", doc.name],

--- a/ferum_customs/custom_logic/service_report_hooks.py
+++ b/ferum_customs/custom_logic/service_report_hooks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 try:
     import frappe
@@ -18,7 +18,8 @@ if TYPE_CHECKING:
         ServiceRequest,
     )
 
-def validate(doc: ServiceReport, method: Optional[str] = None) -> None:
+
+def validate(doc: ServiceReport, method: str | None = None) -> None:
     """Validate the Service Report before submission."""
     if not doc.service_request:
         raise frappe.ValidationError(
@@ -53,7 +54,8 @@ def validate(doc: ServiceReport, method: Optional[str] = None) -> None:
             ).format(STATUS_VYPOLNENA, req_status)
         )
 
-def on_submit(doc: ServiceReport, method: Optional[str] = None) -> None:
+
+def on_submit(doc: ServiceReport, method: str | None = None) -> None:
     """Update the linked Service Request upon submission of the Service Report."""
     if not doc.service_request:
         frappe.logger().warning(
@@ -78,9 +80,7 @@ def on_submit(doc: ServiceReport, method: Optional[str] = None) -> None:
             indicator="green",
             alert=True,
         )
-        frappe.logger().info(
-            f"Заявка '{req.name}' обновлена из отчета '{doc.name}'."
-        )
+        frappe.logger().info(f"Заявка '{req.name}' обновлена из отчета '{doc.name}'.")
 
     except frappe.DoesNotExistError:
         frappe.logger().error(

--- a/ferum_customs/custom_logic/service_request_hooks.py
+++ b/ferum_customs/custom_logic/service_request_hooks.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, List
+from typing import TYPE_CHECKING, Optional
 
 import frappe
 from frappe import _
@@ -21,6 +21,7 @@ from ferum_customs.constants import (
 
 if TYPE_CHECKING:
     from frappe.model.document import Document as FrappeDocument
+
     from ferum_customs.ferum_customs.doctype.service_request.service_request import (
         ServiceRequest,
     )
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
 # --------------------------------------------------------------------------- #
 
 
-def validate(doc: ServiceRequest, method: Optional[str] = None) -> None:
+def validate(doc: ServiceRequest, method: str | None = None) -> None:
     """Validate ``Service Request`` before saving."""
     if doc.status == STATUS_VYPОЛНЕНА and not doc.get(FIELD_CUSTOM_LINKED_REPORT):
         frappe.throw(_("Cannot mark the request as completed without a linked report."))
@@ -42,13 +43,13 @@ def validate(doc: ServiceRequest, method: Optional[str] = None) -> None:
     _ensure_customer(doc)
 
 
-def on_update_after_submit(doc: ServiceRequest, method: Optional[str] = None) -> None:
+def on_update_after_submit(doc: ServiceRequest, method: str | None = None) -> None:
     """Triggered after updating a submitted document."""
     if doc.status == STATUS_ZAKRYTA:
         _notify_project_manager(doc)
 
 
-def prevent_deletion_with_links(doc: ServiceRequest, method: Optional[str] = None) -> None:
+def prevent_deletion_with_links(doc: ServiceRequest, method: str | None = None) -> None:
     """Prevents deletion of the request if there are links to it."""
     if linked_report := frappe.db.exists(
         "Service Report", {"service_request": doc.name}
@@ -91,7 +92,7 @@ def _ensure_customer(doc: ServiceRequest) -> None:
 
 
 @frappe.whitelist(allow_guest=False)
-def get_engineers_for_object(service_object_name: str) -> List[str]:
+def get_engineers_for_object(service_object_name: str) -> list[str]:
     """Returns a list of engineers assigned to the service object."""
     if not service_object_name:
         return []

--- a/ferum_customs/dev_hooks.py
+++ b/ferum_customs/dev_hooks.py
@@ -1,7 +1,7 @@
 """Local development hooks for customizing Frappe/ERPNext behavior.
 
 This file allows you to add overrides or additional hook definitions
-specific to your local development environment. 
+specific to your local development environment.
 
 You can extend fixtures, define custom hooks for events, and more.
 

--- a/ferum_customs/ferum_customs/custom_hooks.py
+++ b/ferum_customs/ferum_customs/custom_hooks.py
@@ -1,8 +1,8 @@
 """DocType hook mapping used by hooks.py."""
 
-from typing import Dict, Any
+from typing import Any
 
-DOC_EVENTS: Dict[str, Dict[str, str]] = {
+DOC_EVENTS: dict[str, dict[str, str]] = {
     "Service Request": {
         "validate": "ferum_customs.custom_logic.service_request_hooks.validate",
         "on_update_after_submit": "ferum_customs.custom_logic.service_request_hooks.on_update_after_submit",

--- a/ferum_customs/ferum_customs/doctype/assigned_engineer_item/assigned_engineer_item.py
+++ b/ferum_customs/ferum_customs/doctype/assigned_engineer_item/assigned_engineer_item.py
@@ -12,13 +12,14 @@ from typing import Optional
 import frappe
 from frappe.model.document import Document
 
+
 class AssignedEngineerItem(Document):
     """
     Document class for the AssignedEngineerItem child table.
     """
 
-    engineer: Optional[str] = None
-    assignment_date: Optional[str] = None
+    engineer: str | None = None
+    assignment_date: str | None = None
 
     def validate(self) -> None:
         """
@@ -46,7 +47,7 @@ class AssignedEngineerItem(Document):
         """
         assignment_date_val = self.get("assignment_date")
         if assignment_date_val:
-            if isinstance(assignment_date_val, (datetime.datetime, datetime.date)):
+            if isinstance(assignment_date_val, datetime.datetime | datetime.date):
                 self.assignment_date = assignment_date_val.isoformat()
             elif isinstance(assignment_date_val, str):
                 try:

--- a/ferum_customs/ferum_customs/doctype/assigned_engineer_item/test_assigned_engineer_item.py
+++ b/ferum_customs/ferum_customs/doctype/assigned_engineer_item/test_assigned_engineer_item.py
@@ -19,7 +19,7 @@ class TestAssignedEngineerItem(FrappeTestCase):
 
         # Assert that the engineer name is stripped of whitespace
         self.assertEqual(doc.engineer.strip(), "Engineer User")
-        
+
         # Assert that the assignment date is in ISO format
         self.assertIn("T", doc.assignment_date)  # Check for 'T' in ISO format
 

--- a/ferum_customs/ferum_customs/doctype/custom_attachment/custom_attachment.py
+++ b/ferum_customs/ferum_customs/doctype/custom_attachment/custom_attachment.py
@@ -4,20 +4,23 @@ Python-контроллер для DocType "Custom Attachment".
 """
 
 from __future__ import annotations
+
 from typing import Optional
 
 import frappe
 from frappe import _  # Для возможных пользовательских сообщений
 from frappe.model.document import Document
 
+
 class CustomAttachment(Document):
     """
     Класс документа CustomAttachment.
-    
+
     Attributes:
         attachment_type (Optional[str]): Тип вложения.
     """
-    attachment_type: Optional[str] = None
+
+    attachment_type: str | None = None
 
     def validate(self) -> None:
         """
@@ -62,11 +65,17 @@ class CustomAttachment(Document):
 
         # Пример бизнес-правила: должен быть указан хотя бы один родитель
         if linked_parents_count == 0 and not self.is_new():
-            frappe.throw(_("Необходимо указать ссылку хотя бы на один родительский документ (Заявка, Отчет или Объект)."))
+            frappe.throw(
+                _(
+                    "Необходимо указать ссылку хотя бы на один родительский документ (Заявка, Отчет или Объект)."
+                )
+            )
 
         # Пример бизнес-правила: должен быть указан ТОЛЬКО один родитель
         if linked_parents_count > 1:
-            frappe.throw(_("Можно указать ссылку только на один родительский документ."))
+            frappe.throw(
+                _("Можно указать ссылку только на один родительский документ.")
+            )
 
     # Хук on_trash для CustomAttachment теперь обрабатывается в
     # ferum_customs.custom_logic.file_attachment_utils.on_custom_attachment_trash

--- a/ferum_customs/ferum_customs/doctype/payroll_entry_custom/payroll_entry_custom.py
+++ b/ferum_customs/ferum_customs/doctype/payroll_entry_custom/payroll_entry_custom.py
@@ -5,15 +5,16 @@ Python-контроллер для DocType "Payroll Entry Custom".
 
 from __future__ import annotations
 
+from typing import Optional
+
 import frappe
 from frappe.model.document import Document
-from typing import Optional
 
 
 class PayrollEntryCustom(Document):
-    total_payable: Optional[float] = None
-    total_deductions: Optional[float] = None
-    net_payable: Optional[float] = None
+    total_payable: float | None = None
+    total_deductions: float | None = None
+    net_payable: float | None = None
     """
     Класс документа PayrollEntryCustom.
     """
@@ -67,7 +68,10 @@ class PayrollEntryCustom(Document):
                     "ServiceReport",
                     filters={
                         "custom_assigned_engineer": self.get("employee"),
-                        "posting_date": ["between", [self.get("start_date"), self.get("end_date")]],
+                        "posting_date": [
+                            "between",
+                            [self.get("start_date"), self.get("end_date")],
+                        ],
                         "docstatus": 1,
                     },
                     fields=["custom_bonus_amount"],
@@ -96,5 +100,5 @@ class PayrollEntryCustom(Document):
         if self.total_payable is None:
             self.total_payable = 0.0
 
-        if isinstance(self.total_payable, (float, int)):
+        if isinstance(self.total_payable, float | int):
             self.total_payable = round(self.total_payable, 2)

--- a/ferum_customs/ferum_customs/doctype/payroll_entry_custom/test_payroll_entry_custom.py
+++ b/ferum_customs/ferum_customs/doctype/payroll_entry_custom/test_payroll_entry_custom.py
@@ -19,8 +19,8 @@ class TestPayrollEntryCustom(FrappeTestCase):
         """Test edge cases for total_payable rounding."""
         edge_cases = [1234.564, 1234.565, 1234.566]
         expected_results = [1234.56, 1234.57, 1234.57]
-        
-        for value, expected in zip(edge_cases, expected_results):
+
+        for value, expected in zip(edge_cases, expected_results, strict=False):
             doc = frappe.new_doc("Payroll Entry Custom")
             doc.total_payable = value
             doc.validate()

--- a/ferum_customs/ferum_customs/doctype/service_object/service_object.py
+++ b/ferum_customs/ferum_customs/doctype/service_object/service_object.py
@@ -4,10 +4,12 @@ Python-контроллер для DocType "Service Object".
 """
 
 from __future__ import annotations
-from frappe.model.document import Document
+
+from typing import Optional
+
 import frappe
 from frappe import _
-from typing import Optional
+from frappe.model.document import Document
 
 
 class ServiceObject(Document):
@@ -17,10 +19,10 @@ class ServiceObject(Document):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.linked_service_project: Optional[str] = None
-        self.object_name: Optional[str] = None
-        self.warranty_expiry_date: Optional[str] = None
-        self.purchase_date: Optional[str] = None
+        self.linked_service_project: str | None = None
+        self.object_name: str | None = None
+        self.warranty_expiry_date: str | None = None
+        self.purchase_date: str | None = None
 
     def validate(self) -> None:
         """
@@ -34,7 +36,9 @@ class ServiceObject(Document):
         # Пример дополнительной валидации:
         if self.warranty_expiry_date and self.purchase_date:
             if self.warranty_expiry_date < self.purchase_date:
-                frappe.throw(_("Дата окончания гарантии не может быть раньше даты покупки."))
+                frappe.throw(
+                    _("Дата окончания гарантии не может быть раньше даты покупки.")
+                )
 
     def _clean_fields(self) -> None:
         """

--- a/ferum_customs/ferum_customs/doctype/service_object/test_service_object.py
+++ b/ferum_customs/ferum_customs/doctype/service_object/test_service_object.py
@@ -14,14 +14,18 @@ class TestServiceObject(FrappeTestCase):
         doc = new_doc("Service Object")  # type: ignore
         doc.linked_service_project = " PROJECT001 "
         doc.validate()
-        self.assertEqual(doc.linked_service_project, "PROJECT001")  # Ensure trimming is tested
+        self.assertEqual(
+            doc.linked_service_project, "PROJECT001"
+        )  # Ensure trimming is tested
 
     def test_linked_service_project_empty(self) -> None:
         """Test that linked_service_project can handle empty string."""
         doc = new_doc("Service Object")  # type: ignore
         doc.linked_service_project = ""
         doc.validate()
-        self.assertEqual(doc.linked_service_project, "")  # Ensure empty string is handled
+        self.assertEqual(
+            doc.linked_service_project, ""
+        )  # Ensure empty string is handled
 
     def test_linked_service_project_none(self) -> None:
         """Test that linked_service_project can handle None."""

--- a/ferum_customs/ferum_customs/doctype/service_project/service_project.py
+++ b/ferum_customs/ferum_customs/doctype/service_project/service_project.py
@@ -31,8 +31,8 @@ class ServiceProject(Document):
         Проверяет корректность дат начала и окончания проекта.
         Даты должны быть объектами date/datetime для сравнения.
         """
-        start_date_val: Optional[str] = self.get("start_date")
-        end_date_val: Optional[str] = self.get("end_date")
+        start_date_val: str | None = self.get("start_date")
+        end_date_val: str | None = self.get("end_date")
 
         if start_date_val and end_date_val:
             try:
@@ -61,7 +61,7 @@ class ServiceProject(Document):
         for fieldname in date_fields:
             field_value = self.get(fieldname)
             if field_value and not isinstance(field_value, str):
-                if isinstance(field_value, (datetime.datetime, datetime.date)):
+                if isinstance(field_value, datetime.datetime | datetime.date):
                     try:
                         setattr(self, fieldname, field_value.isoformat())
                     except Exception as e:

--- a/ferum_customs/ferum_customs/doctype/service_project/test_service_project.py
+++ b/ferum_customs/ferum_customs/doctype/service_project/test_service_project.py
@@ -1,6 +1,7 @@
 import pytest
-from frappe import new_doc, utils, exceptions
+from frappe import exceptions, new_doc, utils
 from frappe.tests.utils import FrappeTestCase
+
 
 class TestServiceProject(FrappeTestCase):
     def test_date_validation(self):
@@ -8,7 +9,7 @@ class TestServiceProject(FrappeTestCase):
         doc = new_doc("Service Project")
         doc.start_date = utils.now_datetime()
         doc.end_date = utils.add_days(doc.start_date, -1)
-        
+
         with pytest.raises(exceptions.ValidationError):
             doc.validate()
 
@@ -17,6 +18,6 @@ class TestServiceProject(FrappeTestCase):
         doc = new_doc("Service Project")
         doc.start_date = utils.now_datetime()
         doc.end_date = utils.add_days(doc.start_date, 1)
-        
+
         # This should not raise any exceptions
         doc.validate()  # Ensure that no exceptions are raised

--- a/ferum_customs/ferum_customs/doctype/service_report/service_report.py
+++ b/ferum_customs/ferum_customs/doctype/service_report/service_report.py
@@ -6,7 +6,7 @@ Python controller for DocType "Service Report".
 from __future__ import annotations
 
 import datetime
-from typing import Optional, List, Dict
+from typing import Optional
 
 import frappe
 from frappe import _
@@ -14,8 +14,8 @@ from frappe.model.document import Document
 
 
 class ServiceReport(Document):
-    service_request: Optional[str] = None
-    customer: Optional[str] = None
+    service_request: str | None = None
+    customer: str | None = None
     total_quantity: float = 0.0
     total_payable: float = 0.0
 
@@ -44,14 +44,14 @@ class ServiceReport(Document):
         posting_date_val = self.get("posting_date")
         if posting_date_val:
             if not isinstance(posting_date_val, str):
-                if isinstance(posting_date_val, (datetime.datetime, datetime.date)):
+                if isinstance(posting_date_val, datetime.datetime | datetime.date):
                     self.posting_date = posting_date_val.isoformat()
         else:
             if self.is_new() and self.meta.get_field("posting_date").reqd:
                 self.posting_date = frappe.utils.nowdate()
 
     def _validate_work_items(self) -> None:
-        work_items_table: List[Dict] = self.get("work_items") or []
+        work_items_table: list[dict] = self.get("work_items") or []
         if not work_items_table:
             return
 
@@ -60,7 +60,9 @@ class ServiceReport(Document):
             description = item.get("description", "").strip()
             if not description:
                 frappe.throw(
-                    _("Description is required for all work items (row {0}).").format(row_num)
+                    _("Description is required for all work items (row {0}).").format(
+                        row_num
+                    )
                 )
             item["description"] = description
 
@@ -96,7 +98,7 @@ class ServiceReport(Document):
         total_qty: float = 0.0
         total_pay: float = 0.0
 
-        work_items_table: List[Dict] = self.get("work_items", [])
+        work_items_table: list[dict] = self.get("work_items", [])
 
         for item in work_items_table:
             try:

--- a/ferum_customs/ferum_customs/doctype/service_report/test_service_report.py
+++ b/ferum_customs/ferum_customs/doctype/service_report/test_service_report.py
@@ -26,16 +26,18 @@ class TestServiceReport(FrappeTestCase):
             },
         )
         doc.validate()
-        
+
         # Validate posting date format
         self.assertTrue(
             doc.posting_date.endswith("Z")
             or re.match(r".*\+\d{2}:\d{2}", doc.posting_date.isoformat())
         )
-        
+
         # Validate work items
         for item in doc.work_items:
             self.assertEqual(item.description, "Test work item")
             self.assertAlmostEqual(item.quantity, 2.56, places=2)
             self.assertAlmostEqual(item.unit_price, 100.56, places=2)
-            self.assertAlmostEqual(item.amount, item.quantity * item.unit_price, places=2)
+            self.assertAlmostEqual(
+                item.amount, item.quantity * item.unit_price, places=2
+            )

--- a/ferum_customs/ferum_customs/doctype/service_report_document_item/service_report_document_item.py
+++ b/ferum_customs/ferum_customs/doctype/service_report_document_item/service_report_document_item.py
@@ -3,18 +3,19 @@
 
 from frappe.model.document import Document
 
+
 class ServiceReportDocumentItem(Document):
     """Represents an item in the service report document.
 
-    This class currently does not implement any specific logic. 
+    This class currently does not implement any specific logic.
     Frappe will use the standard behavior for child documents.
     If validation or other logic is needed, it can be added here.
-    
+
     Attributes:
         item_code (str): The code of the item.
         quantity (int): The quantity of the item.
     """
-    
+
     item_code: str
     quantity: int
 

--- a/ferum_customs/ferum_customs/doctype/service_report_work_item/service_report_work_item.py
+++ b/ferum_customs/ferum_customs/doctype/service_report_work_item/service_report_work_item.py
@@ -1,13 +1,14 @@
 # Copyright (c) 2025 Ferum LLC and contributors
 # For license information, please see license.txt
 
-from frappe.model.document import Document
 from frappe import _
+from frappe.model.document import Document
+
 
 class ServiceReportWorkItem(Document):
-    """Represents a work item in a service report. 
+    """Represents a work item in a service report.
     This DocType is used to manage individual work items associated with service reports.
-    
+
     Attributes:
         field_name (str): Description of the field.
         another_field (int): Description of another field.

--- a/ferum_customs/ferum_customs/doctype/service_request/service_request.py
+++ b/ferum_customs/ferum_customs/doctype/service_request/service_request.py
@@ -29,15 +29,15 @@ class ServiceRequest(Document):  # type: ignore[misc]
     # Аннотации типов для полей DocType
     subject: DF.Data
     status: DF.Data
-    custom_customer: Optional[DF.Link]
-    custom_service_object_link: Optional[DF.Link]
-    custom_project: Optional[DF.Link]
+    custom_customer: DF.Link | None
+    custom_service_object_link: DF.Link | None
+    custom_project: DF.Link | None
     request_datetime: DF.Datetime
-    completed_on: Optional[DF.Datetime]
-    planned_start_datetime: Optional[DF.Datetime]
-    planned_end_datetime: Optional[DF.Datetime]
-    actual_start_datetime: Optional[DF.Datetime]
-    actual_end_datetime: Optional[DF.Datetime]
+    completed_on: DF.Datetime | None
+    planned_start_datetime: DF.Datetime | None
+    planned_end_datetime: DF.Datetime | None
+    actual_start_datetime: DF.Datetime | None
+    actual_end_datetime: DF.Datetime | None
     duration_hours: DF.Float
 
     def validate(self) -> None:

--- a/ferum_customs/ferum_customs/doctype/service_request/test_service_request.py
+++ b/ferum_customs/ferum_customs/doctype/service_request/test_service_request.py
@@ -1,6 +1,7 @@
-from unittest.mock import patch
-import pytest
 from typing import Optional
+from unittest.mock import patch
+
+import pytest
 
 try:
     import frappe
@@ -17,6 +18,7 @@ TEST_PM_USER_EMAIL = "test_sr_pm_ferum@example.com"
 TEST_SP_NAME_FIELD = "_Test SP for SR Tests"
 ACTUAL_TEST_SP_NAME = TEST_SP_NAME_FIELD
 ACTUAL_TEST_SO_NAME = "_Test SO for SR Tests"
+
 
 class TestServiceRequest(FrappeTestCase):
     test_customer_name: str = TEST_CUSTOMER_NAME
@@ -35,7 +37,9 @@ class TestServiceRequest(FrappeTestCase):
         frappe.set_user(self.current_user_for_test)
         frappe.db.rollback()
 
-    def create_service_request_doc(self, status: str = STATUS_OTKRYTA, submit_doc: bool = False) -> Optional[frappe.Document]:
+    def create_service_request_doc(
+        self, status: str = STATUS_OTKRYTA, submit_doc: bool = False
+    ) -> frappe.Document | None:
         """Create a Service Request document with the given status."""
         sr = frappe.new_doc("Service Request")
         sr.subject = "Test SR - " + frappe.generate_hash(length=5)
@@ -49,7 +53,9 @@ class TestServiceRequest(FrappeTestCase):
                 sr.submit()
             except frappe.exceptions.DoesNotExistError as e:
                 if "WorkflowState" in str(e) and "Открыта" in str(e):
-                    frappe.get_doc("Workflow State", {"workflow_state_name": "Открыта"}).save(ignore_permissions=True)
+                    frappe.get_doc(
+                        "Workflow State", {"workflow_state_name": "Открыта"}
+                    ).save(ignore_permissions=True)
                     sr.reload()
                     sr.submit()
                 else:
@@ -70,24 +76,33 @@ class TestServiceRequest(FrappeTestCase):
         sr = self.create_service_request_doc(status=STATUS_OTKRYTA, submit_doc=True)
         sr.status = STATUS_VYPOLNENA
 
-        with self.assertRaisesRegex(frappe.ValidationError, "Нельзя отметить заявку выполненной без связанного отчёта"):
+        with self.assertRaisesRegex(
+            frappe.ValidationError,
+            "Нельзя отметить заявку выполненной без связанного отчёта",
+        ):
             sr.save()
 
     def test_hook_get_engineers_for_object(self, frappe_site) -> None:
         """Test the hook to get engineers for the service object."""
-        from ferum_customs.custom_logic.service_request_hooks import get_engineers_for_object
+        from ferum_customs.custom_logic.service_request_hooks import (
+            get_engineers_for_object,
+        )
 
         engineers = get_engineers_for_object(self.actual_test_so_name)
         self.assertIn(self.test_engineer_user_email, engineers)
 
-    def test_sr_controller_internal_methods_with_custom_fields(self, frappe_site) -> None:
+    def test_sr_controller_internal_methods_with_custom_fields(
+        self, frappe_site
+    ) -> None:
         """Test internal methods of Service Request controller with custom fields."""
         sr_doc = frappe.new_doc("Service Request")
         sr_doc.subject = " Test Subject for Cleaning "
         sr_doc.planned_start_datetime = now_datetime()
         sr_doc.planned_end_datetime = add_days(now_datetime(), -1)
 
-        with self.assertRaisesRegex(frappe.ValidationError, "Планируемая дата начала не может быть позже"):
+        with self.assertRaisesRegex(
+            frappe.ValidationError, "Планируемая дата начала не может быть позже"
+        ):
             sr_doc.validate()
 
         sr_doc.planned_end_datetime = add_days(now_datetime(), 1)
@@ -101,7 +116,9 @@ class TestServiceRequest(FrappeTestCase):
         self.assertAlmostEqual(sr_doc.duration_hours, 12.0, places=2)
 
     @patch("frappe.sendmail")
-    def test_notify_project_manager_on_close(self, mock_sendmail_func, frappe_site) -> None:
+    def test_notify_project_manager_on_close(
+        self, mock_sendmail_func, frappe_site
+    ) -> None:
         """Test notification to project manager when the service request is closed."""
         sr = self.create_service_request_doc(status=STATUS_OTKRYTA, submit_doc=True)
 

--- a/ferum_customs/ferum_customs/hooks.py
+++ b/ferum_customs/ferum_customs/hooks.py
@@ -1,7 +1,8 @@
 # Ferum Customs - hooks
-from typing import Any, Dict  # Import Dict for type hinting
-from ferum_customs.custom_hooks import DOC_EVENTS
+from typing import Any
+
 from ferum_customs.bench_commands.run_tests import run_tests
+from ferum_customs.custom_hooks import DOC_EVENTS
 
 app_name = "ferum_customs"
 app_title = "Ferum Customs"
@@ -23,7 +24,9 @@ permission_query_conditions = {
     "Service Request": "ferum_customs.permissions.permissions.get_service_request_pqc",
 }
 
-get_notification_config = "ferum_customs.notifications.notifications.get_notification_config"
+get_notification_config = (
+    "ferum_customs.notifications.notifications.get_notification_config"
+)
 
 # Fixtures for the app
 fixtures = [
@@ -36,24 +39,18 @@ fixtures = [
     "DocPerm",
 ]
 
+
 # Bench commands: custom CLI tools for this app
-def get_bench_commands() -> Dict[str, Any]:
+def get_bench_commands() -> dict[str, Any]:
     return [
-        {
-            "command": run_tests,
-            "description": "Run custom tests for Ferum Customs"
-        },
+        {"command": run_tests, "description": "Run custom tests for Ferum Customs"},
     ]
 
-def scheduler_events() -> Dict[str, Any]:  # Use Dict for type hinting
+
+def scheduler_events() -> dict[str, Any]:  # Use Dict for type hinting
     """Return scheduler events configuration for Frappe."""
-    return {
-        "cron": {
-            "0 * * * *": [
-                "ferum_customs.tasks.run_scheduled_task"
-            ]
-        }
-    }
+    return {"cron": {"0 * * * *": ["ferum_customs.tasks.run_scheduled_task"]}}
+
 
 try:  # dev-hooks (если есть)
     from ferum_customs.dev_hooks import *  # Avoid wildcard imports

--- a/ferum_customs/ferum_customs/report/engineer_workload/engineer_workload.py
+++ b/ferum_customs/ferum_customs/report/engineer_workload/engineer_workload.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Tuple, List, Dict
+from typing import Any, Optional
 
 import frappe
 from frappe import _
@@ -10,8 +10,8 @@ from ferum_customs.constants import STATUS_OTMENENA, STATUS_ZAKRYTA
 
 @frappe.whitelist()
 def execute(
-    filters: Optional[dict] = None
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    filters: dict | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """
     Execute the engineer workload report.
 

--- a/ferum_customs/ferum_customs/report/service_request_overview/service_request_overview.py
+++ b/ferum_customs/ferum_customs/report/service_request_overview/service_request_overview.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Tuple, List, Dict
+from typing import Any, Optional
 
 import frappe
 from frappe import _
@@ -9,8 +9,8 @@ from ferum_customs.constants import STATUS_OTMENENA, STATUS_ZAKRYTA
 
 
 def execute(
-    filters: Optional[Dict[str, Any]] = None
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    filters: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """
     Execute the service request overview report.
 

--- a/ferum_customs/ferum_customs/test_api.py
+++ b/ferum_customs/ferum_customs/test_api.py
@@ -1,6 +1,6 @@
 import pytest
-from frappe.tests.utils import FrappeTestCase
 from frappe.exceptions import DoesNotExistError
+from frappe.tests.utils import FrappeTestCase
 
 from ferum_customs import api
 
@@ -8,11 +8,11 @@ from ferum_customs import api
 class TestAPI(FrappeTestCase):
     def test_validate_service_request(self) -> None:
         """Test validate_service_request method for valid and invalid cases."""
-        
+
         # Test with a valid document name
         doc = api.validate_service_request("test_docname")
         self.assertIsNotNone(doc)
-        self.assertEqual(getattr(doc, 'name', None), "test_docname")
+        self.assertEqual(getattr(doc, "name", None), "test_docname")
 
         # Test with an invalid document name
         with self.assertRaises(DoesNotExistError):

--- a/ferum_customs/install.py
+++ b/ferum_customs/install.py
@@ -37,9 +37,13 @@ def after_install() -> None:
 
 def create_initial_data() -> None:
     """Create initial data for the application."""
-    if not frappe.db.exists("ServiceType", {"service_type_name": "Standard Maintenance"}):  # Example DocType
-        frappe.get_doc({
-            "doctype": "ServiceType",
-            "service_type_name": "Standard Maintenance",
-            "default_duration_hours": 2
-        }).insert()
+    if not frappe.db.exists(
+        "ServiceType", {"service_type_name": "Standard Maintenance"}
+    ):  # Example DocType
+        frappe.get_doc(
+            {
+                "doctype": "ServiceType",
+                "service_type_name": "Standard Maintenance",
+                "default_duration_hours": 2,
+            }
+        ).insert()

--- a/ferum_customs/notifications/notifications.py
+++ b/ferum_customs/notifications/notifications.py
@@ -8,7 +8,7 @@
 Возвращает словарь, описывающий условия для отправки стандартных уведомлений Frappe.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 from frappe import _  # Для перевода возможных строк в будущем
 
@@ -16,7 +16,7 @@ from frappe import _  # Для перевода возможных строк в
 from ferum_customs.constants import ROLE_PROEKTNYJ_MENEDZHER
 
 
-def get_notification_config() -> Dict[str, Any]:
+def get_notification_config() -> dict[str, Any]:
     """
     Возвращает конфигурацию для стандартных уведомлений Frappe.
 

--- a/ferum_customs/openai_utils.py
+++ b/ferum_customs/openai_utils.py
@@ -1,13 +1,17 @@
-import os
-import openai
 import logging
+import os
 from typing import Optional
+
+import openai
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def get_chat_completion(prompt: str, model: Optional[str] = "gpt-4", max_tokens: Optional[int] = 150) -> Optional[str]:
+
+def get_chat_completion(
+    prompt: str, model: str | None = "gpt-4", max_tokens: int | None = 150
+) -> str | None:
     """
     Generates a chat completion response from OpenAI's API.
 
@@ -22,26 +26,31 @@ def get_chat_completion(prompt: str, model: Optional[str] = "gpt-4", max_tokens:
     # Ensure the API key is retrieved securely
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        raise ValueError("API key not found. Please set the OPENAI_API_KEY environment variable.")
+        raise ValueError(
+            "API key not found. Please set the OPENAI_API_KEY environment variable."
+        )
 
     openai.api_key = api_key
 
     # Validate model
     allowed_models = ["gpt-3.5-turbo", "gpt-4"]
     if model not in allowed_models:
-        raise ValueError(f"Model '{model}' is not allowed. Choose from {allowed_models}.")
+        raise ValueError(
+            f"Model '{model}' is not allowed. Choose from {allowed_models}."
+        )
 
     try:
         sanitized_prompt = sanitize_input(prompt)
         response = openai.ChatCompletion.create(
             model=model,
             messages=[{"role": "user", "content": sanitized_prompt}],
-            max_tokens=max_tokens
+            max_tokens=max_tokens,
         )
-        return response.choices[0].message['content'].strip()
+        return response.choices[0].message["content"].strip()
     except openai.error.OpenAIError as e:
         logger.error(f"An error occurred: {e}")
         return None
+
 
 def sanitize_input(prompt: str) -> str:
     """

--- a/ferum_customs/patches/create_custom_roles_and_permissions.py
+++ b/ferum_customs/patches/create_custom_roles_and_permissions.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import frappe
 from typing import Union
+
+import frappe
 
 ROLES = [
     "Проектный менеджер",
@@ -11,7 +12,7 @@ ROLES = [
     "Заказчик",
 ]
 
-SERVICE_REQUEST_PERMS: list[dict[str, Union[int, str]]] = [
+SERVICE_REQUEST_PERMS: list[dict[str, int | str]] = [
     {
         "parent": "Service Request",
         "role": "Проектный менеджер",
@@ -75,7 +76,7 @@ def create_role(role_name: str) -> None:
     role.insert(ignore_permissions=True)
 
 
-def create_docperm(perm: dict[str, Union[int, str]]) -> None:
+def create_docperm(perm: dict[str, int | str]) -> None:
     """Insert DocPerm if it is missing."""
     filters = {
         "parent": perm["parent"],

--- a/ferum_customs/patches/v1_0/rename_project_to_service_project.py
+++ b/ferum_customs/patches/v1_0/rename_project_to_service_project.py
@@ -1,11 +1,14 @@
 # ferum_customs/patches/v1_0/rename_project_to_service_project.py
 import frappe
-from frappe.model.rename_doc import rename_doc
 from frappe import _
+from frappe.model.rename_doc import rename_doc
+
 
 def execute() -> None:
     """Renames DocType 'Project' to 'Service Project' if needed."""
-    if frappe.db.exists("DocType", "Project") and not frappe.db.exists("DocType", "Service Project"):
+    if frappe.db.exists("DocType", "Project") and not frappe.db.exists(
+        "DocType", "Service Project"
+    ):
         frappe.logger().info("Renaming DocType 'Project' to 'Service Project'...")
         try:
             rename_doc(
@@ -18,11 +21,13 @@ def execute() -> None:
             frappe.logger().info("Successfully renamed 'Project' to 'Service Project'.")
         except Exception as e:
             frappe.log_error(
-                message=f"Error renaming DocType Project to Service Project: {e}", 
-                title="Patch Error"
+                message=f"Error renaming DocType Project to Service Project: {e}",
+                title="Patch Error",
             )
             frappe.throw(_("Error during rename: {0}").format(e))
     elif not frappe.db.exists("DocType", "Project"):
         frappe.logger().info("DocType 'Project' does not exist. Skipping rename.")
     elif frappe.db.exists("DocType", "Service Project"):
-        frappe.logger().info("DocType 'Service Project' already exists. Skipping rename.")
+        frappe.logger().info(
+            "DocType 'Service Project' already exists. Skipping rename."
+        )

--- a/ferum_customs/permissions/permissions.py
+++ b/ferum_customs/permissions/permissions.py
@@ -7,17 +7,18 @@ This module provides dynamic conditions for permission queries based on user rol
 
 from __future__ import annotations
 
-from typing import Optional, Dict, List, Tuple
+from typing import Optional
+
 import frappe
 
 from ferum_customs.constants import ROLE_CUSTOMER, ROLE_ZAKAZCHIK
 
-PQCConditionValue = Union[str, List[Union[str, List[str]]], Dict[str, str], Tuple[str, str]]
-PQCConditions = Dict[str, PQCConditionValue]
+PQCConditionValue = str | list[str | list[str]] | dict[str, str] | tuple[str, str]
+PQCConditions = dict[str, PQCConditionValue]
 
 
 @frappe.whitelist()
-def get_service_request_pqc(user: Optional[str] = None) -> Optional[PQCConditions]:
+def get_service_request_pqc(user: str | None = None) -> PQCConditions | None:
     """
     Get permission query conditions for service requests based on the user's roles and linked customer.
 

--- a/locustfile.py
+++ b/locustfile.py
@@ -1,5 +1,7 @@
-from locust import HttpUser, between, task
 import logging
+
+from locust import HttpUser, between, task
+
 
 class WebsiteUser(HttpUser):
     """User class for load testing the website."""
@@ -11,4 +13,6 @@ class WebsiteUser(HttpUser):
         """Task to check the health of the application."""
         response = self.client.get("/health")
         if response.status_code != 200:
-            logging.error(f"Health check failed with status code {response.status_code}")
+            logging.error(
+                f"Health check failed with status code {response.status_code}"
+            )

--- a/scripts/check_fixtures_doctype.py
+++ b/scripts/check_fixtures_doctype.py
@@ -4,7 +4,6 @@
 import json
 import sys
 from pathlib import Path
-from typing import List, Optional
 
 
 def check_file(path: Path) -> bool:
@@ -21,7 +20,7 @@ def check_file(path: Path) -> bool:
     return not missing
 
 
-def main(paths: List[str]) -> int:
+def main(paths: list[str]) -> int:
     """Main function to check multiple JSON files for 'doctype' field."""
     ok = True
     for path_str in paths:

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -6,8 +6,9 @@ This script reads the settings from the environment and generates a
 variables.
 """
 
-from ferum_customs.config.settings import Settings
 import os
+
+from ferum_customs.config.settings import Settings
 
 
 def main() -> None:
@@ -15,19 +16,19 @@ def main() -> None:
     settings = Settings(telegram_bot_token=os.getenv("TELEGRAM_BOT_TOKEN", ""))
     fields = settings.model_fields
     lines = ["# Generated .env.example"]
-    
+
     for name, _ in fields.items():
         key = name.upper()
         default = getattr(settings, name, "")
         lines.append(f"{key}={default if default is not None else ''}")
 
     content = "\n".join(lines) + "\n"
-    
+
     try:
         with open(".env.example", "w", encoding="utf-8") as f:
             f.write(content)
         print("✅ .env.example generated.")
-    except IOError as e:
+    except OSError as e:
         print(f"❌ Error writing .env.example: {e}")
 
 

--- a/scripts/gpt_full_review.py
+++ b/scripts/gpt_full_review.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Asynchronous GPT-powered code review helper.
 Version: 2.1 (fixes and improvements as of 2025-07-31)
@@ -17,9 +16,10 @@ import pathlib
 import random
 import re
 import textwrap
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from hashlib import md5
-from typing import Dict, Final, Iterable, List, Optional, Set
+from typing import Final, Optional
 
 import pathspec
 import tiktoken
@@ -52,7 +52,7 @@ OPENAI_RETRY_ATTEMPTS: Final[int] = 6
 OPENAI_BASE_DELAY: Final[float] = 2.0
 OPENAI_MAX_DELAY: Final[float] = 30.0
 
-EXTS: Final[Set[str]] = {
+EXTS: Final[set[str]] = {
     ".py",
     ".js",
     ".ts",
@@ -67,7 +67,7 @@ EXTS: Final[Set[str]] = {
     ".sh",
     ".sql",
 }
-IGNORE_EXTS: Final[Set[str]] = {
+IGNORE_EXTS: Final[set[str]] = {
     ".zip",
     ".tar",
     ".gz",
@@ -86,7 +86,7 @@ IGNORE_EXTS: Final[Set[str]] = {
     ".pem",
     ".log",
 }
-IGNORE_PATTERNS: Final[Set[str]] = {
+IGNORE_PATTERNS: Final[set[str]] = {
     "node_modules",
     "__pycache__",
     ".git",
@@ -115,7 +115,7 @@ SYSTEM_MSG: Final[str] = (
     "Provide no commentary outside the list or code block."
 )
 
-SECRET_PATTERNS: Final[List[re.Pattern[str]]] = [
+SECRET_PATTERNS: Final[list[re.Pattern[str]]] = [
     re.compile(r"AKIA[0-9A-Z]{16}"),
     re.compile(r"(?:ghp|gho|ghs|ghu)_[0-9A-Za-z]{36}"),
     re.compile(r"-----BEGIN (?:RSA|EC) PRIVATE KEY-----"),

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "Framework :: Frappe",
         "Framework :: ERPNext",
     ],
-    python_requires='>=3.6',  # Specify the minimum Python version
+    python_requires=">=3.6",  # Specify the minimum Python version
 )
 
 # Changelog:

--- a/telegram_bot/bot_service.py
+++ b/telegram_bot/bot_service.py
@@ -12,6 +12,7 @@ whitelisted API methods defined in :mod:`ferum_customs.api`.
 """
 
 from __future__ import annotations
+
 from typing import Optional
 
 from aiogram import Bot, Dispatcher
@@ -51,14 +52,16 @@ app = FastAPI(title="Ferum Bot Service")
 
 
 def _create_dispatcher(
-    bot: Optional[Bot] = None,
-    storage: Optional[BaseStorage] = None,
+    bot: Bot | None = None,
+    storage: BaseStorage | None = None,
 ) -> Dispatcher:
     """Instantiate dispatcher with in‑memory storage."""
-    
+
     if bot is None:
         if not settings.telegram_bot_token:
-            raise HTTPException(status_code=500, detail="Telegram bot token is not set.")
+            raise HTTPException(
+                status_code=500, detail="Telegram bot token is not set."
+            )
         bot = Bot(settings.telegram_bot_token)
     if storage is None:
         storage = MemoryStorage()
@@ -66,7 +69,7 @@ def _create_dispatcher(
 
 
 def get_dispatcher(
-    *, bot: Optional[Bot] = None, storage: Optional[BaseStorage] = None
+    *, bot: Bot | None = None, storage: BaseStorage | None = None
 ) -> Dispatcher:
     """Return a dispatcher instance for external usage (e.g. tests)."""
 
@@ -89,7 +92,7 @@ async def start_handler(bot: Bot, message: Message, state: FSMContext) -> None:
 @app.on_event("startup")
 async def startup_event() -> None:
     """Hook that runs on service startup."""
-    
+
     # Initialize any necessary resources or configurations here.
     pass
 
@@ -97,7 +100,7 @@ async def startup_event() -> None:
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
     """Hook that runs on service shutdown."""
-    
+
     await dispatcher.storage.close()
 
 

--- a/telegram_bot/handlers.py
+++ b/telegram_bot/handlers.py
@@ -11,4 +11,7 @@ Functions:
 
 from .bot_service import IncidentStates, start_handler
 
-__all__ = ["start_handler", "IncidentStates"]  # Expose the main handler and incident states for external use.
+__all__ = [
+    "start_handler",
+    "IncidentStates",
+]  # Expose the main handler and incident states for external use.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 import sys
 import types
-import pytest
-from typing import Any, Callable, Dict
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock
+
+import pytest
 
 # Provide minimal aiogram stubs so tests can run without the real library
 if "aiogram" not in sys.modules:

--- a/tests/e2e/test_fsm_conversation.py
+++ b/tests/e2e/test_fsm_conversation.py
@@ -18,13 +18,14 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 else:
     aiogram_types = importlib.import_module("aiogram.types")
 
+
 @pytest.mark.asyncio
 async def test_fsm_start_handler():
     """Test the start handler of the FSM to ensure it transitions to the correct state."""
-    
+
     bot_token = os.getenv("BOT_TOKEN")  # Retrieve from environment
     assert bot_token is not None, "BOT_TOKEN must be set in the environment"
-    
+
     bot: Bot = Bot(token=bot_token)
     storage: MemoryStorage = MemoryStorage()
     key: StorageKey = StorageKey(bot_id=bot.id or 0, chat_id=123, user_id=123)

--- a/tests/e2e/test_placeholder.py
+++ b/tests/e2e/test_placeholder.py
@@ -5,7 +5,10 @@ End-to-end tests for the placeholder functionality.
 This module contains tests that validate the basic functionality of the application, specifically the placeholder feature.
 """
 
+
 @pytest.mark.slow
 def test_placeholder_functionality() -> None:
     """Test that a basic assertion holds true for the placeholder functionality."""
-    assert 3 == 3  # This is a placeholder test; replace with actual functionality tests.
+    assert (
+        3 == 3
+    )  # This is a placeholder test; replace with actual functionality tests.

--- a/tests/e2e/test_service_request_flow.py
+++ b/tests/e2e/test_service_request_flow.py
@@ -1,8 +1,10 @@
 import pytest
 from frappe import db
 from frappe.tests.utils import FrappeTestCase
+
 from ferum_customs import api
 from ferum_customs.constants import STATUS_OTKRYTA
+
 
 @pytest.mark.slow
 class TestServiceRequestFlow(FrappeTestCase):
@@ -10,15 +12,20 @@ class TestServiceRequestFlow(FrappeTestCase):
 
     def test_full_flow(self, frappe_site: str) -> None:
         """Test the complete service request flow from creation to retrieval."""
-        
+
         # Ensure the service request is created successfully
         sr_name = api.bot_create_service_request("E2E Subject")
         self.assertIsNotNone(sr_name, "Service request creation failed, returned None")
-        
+
         # Check if the service request exists in the database
-        self.assertTrue(db.exists("Service Request", sr_name), f"Service Request {sr_name} does not exist in the database")
-        
+        self.assertTrue(
+            db.exists("Service Request", sr_name),
+            f"Service Request {sr_name} does not exist in the database",
+        )
+
         # Retrieve open service requests and check if the created request is among them
         open_requests = api.bot_get_service_requests(status=STATUS_OTKRYTA)
         names = [r["name"] for r in open_requests]
-        self.assertIn(sr_name, names, f"Service Request {sr_name} not found in open requests")
+        self.assertIn(
+            sr_name, names, f"Service Request {sr_name} not found in open requests"
+        )

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -12,8 +12,15 @@ class TestAPIIntegration(FrappeTestCase):
         # Ensure the test is isolated by using a transaction or a test site
         with self.frappe_site:
             name = api.bot_create_service_request("From bot", description="demo")
-            self.assertTrue(frappe.db.exists("Service Request", name), "Service Request was not created.")
-            
+            self.assertTrue(
+                frappe.db.exists("Service Request", name),
+                "Service Request was not created.",
+            )
+
             results = api.bot_get_service_requests()
             service_request_names = [r["name"] for r in results]
-            self.assertIn(name, service_request_names, "Service Request name not found in the results.")
+            self.assertIn(
+                name,
+                service_request_names,
+                "Service Request name not found in the results.",
+            )

--- a/tests/integration/test_api_base.py
+++ b/tests/integration/test_api_base.py
@@ -7,11 +7,15 @@ from ferum_customs.api import app
 
 client: TestClient = TestClient(app)
 
+
 def test_root_endpoint() -> None:
     """Test the root endpoint of the API to ensure it returns the expected welcome message."""
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == {"message": "Welcome to the API!"}  # Example expected response
+    assert response.json() == {
+        "message": "Welcome to the API!"
+    }  # Example expected response
+
 
 def test_root_endpoint_not_found() -> None:
     """Test the root endpoint for a non-existent route."""

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -1,15 +1,17 @@
 import pytest
 
+
 @pytest.fixture
 def setup_placeholder_data():
     # Setup necessary data for the placeholder functionality
     # Example: Create a placeholder object in the database
     pass  # Replace with actual setup logic
 
+
 def test_integration_placeholder(setup_placeholder_data):
     """
     Test the integration of the placeholder functionality.
-    
+
     This test verifies that the placeholder functionality behaves as expected
     when provided with the necessary setup data.
     """

--- a/tests/integration/test_service_api.py
+++ b/tests/integration/test_service_api.py
@@ -3,18 +3,22 @@ import pytest
 pytest.importorskip("frappe")
 
 from fastapi.testclient import TestClient
+
 from ferum_customs.api import app
 
 client = TestClient(app)
 
+
 def test_health_check() -> None:
     """Test the health check endpoint to ensure the service is running and returns the expected response."""
     response = client.get("/health")
-    
+
     # Assert that the response status code is 200
     assert response.status_code == 200
-    
+
     # Assert that the response JSON matches the expected structure
-    assert response.json() == {"status": "healthy"}  # Assuming the expected response structure
+    assert response.json() == {
+        "status": "healthy"
+    }  # Assuming the expected response structure
 
     # Additional assertions can be added here to cover edge cases

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import List
+
 
 def test_basic_imports() -> None:
     """Ensure that core dependencies are available for import.
@@ -8,7 +8,7 @@ def test_basic_imports() -> None:
     If any module is not found, an AssertionError will be raised. All specified modules
     should be importable without errors.
     """
-    modules: List[str] = ["aiogram", "fastapi", "requests_oauthlib"]
+    modules: list[str] = ["aiogram", "fastapi", "requests_oauthlib"]
 
     for module in modules:
         try:

--- a/tests/unit/test_api_bot.py
+++ b/tests/unit/test_api_bot.py
@@ -1,14 +1,16 @@
 import importlib
 from types import SimpleNamespace
-from ferum_customs.constants import STATUS_OTKRYTA
 from unittest.mock import MagicMock
+
+from ferum_customs.constants import STATUS_OTKRYTA
+
 
 def test_bot_create_and_update(frappe_stub: MagicMock) -> None:
     api = importlib.reload(importlib.import_module("ferum_customs.api"))
 
     calls = {}
 
-    def get_doc(arg1: str, arg2: str = None) -> SimpleNamespace:
+    def get_doc(arg1: str, arg2: str | None = None) -> SimpleNamespace:
         if isinstance(arg1, dict):
             doc = SimpleNamespace(name="SR001")
 
@@ -41,7 +43,7 @@ def test_bot_upload_attachment(frappe_stub: MagicMock) -> None:
 
     recorded = {}
 
-    def get_doc(arg1: str, arg2: str = None) -> SimpleNamespace:
+    def get_doc(arg1: str, arg2: str | None = None) -> SimpleNamespace:
         if isinstance(arg1, dict):
             doc = SimpleNamespace(name="CA001")
 

--- a/tests/unit/test_api_invoice.py
+++ b/tests/unit/test_api_invoice.py
@@ -1,6 +1,8 @@
 import importlib
 from types import SimpleNamespace
+
 import pytest
+
 
 @pytest.mark.unit
 def test_create_invoice_from_report(frappe_stub):

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -1,23 +1,35 @@
 from fastapi.testclient import TestClient
+
 from ferum_customs.api import app
 
 client = TestClient(app)
+
 
 def test_root_route() -> None:
     """Test the root endpoint of FastAPI, expecting a successful response with a JSON payload."""
     response = client.get("/")
     assert response.status_code == 200, "Expected status code 200 for root route"
     assert response.json() == {"ok": True}, "Expected JSON response to be {'ok': True}"
-    assert response.headers["Content-Type"] == "application/json", "Expected Content-Type to be application/json"
+    assert (
+        response.headers["Content-Type"] == "application/json"
+    ), "Expected Content-Type to be application/json"
+
 
 def test_health_route() -> None:
     """Test the health endpoint of FastAPI, expecting a healthy status response."""
     response = client.get("/health")
     assert response.status_code == 200, "Expected status code 200 for health route"
-    assert response.json() == {"status": "ok"}, "Expected JSON response to be {'status': 'ok'}"
-    assert response.headers["Content-Type"] == "application/json", "Expected Content-Type to be application/json"
+    assert response.json() == {
+        "status": "ok"
+    }, "Expected JSON response to be {'status': 'ok'}"
+    assert (
+        response.headers["Content-Type"] == "application/json"
+    ), "Expected Content-Type to be application/json"
+
 
 def test_non_existent_route() -> None:
     """Test a non-existent route to ensure it returns a 404 status."""
     response = client.get("/non-existent")
-    assert response.status_code == 404, "Expected status code 404 for non-existent route"
+    assert (
+        response.status_code == 404
+    ), "Expected status code 404 for non-existent route"

--- a/tests/unit/test_bot_service.py
+++ b/tests/unit/test_bot_service.py
@@ -1,8 +1,8 @@
 import importlib
+import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
-import os
 
 import pytest
 from aiogram import Bot
@@ -18,6 +18,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 
 from telegram_bot.bot_service import IncidentStates, get_dispatcher, start_handler
 
+
 @pytest.fixture
 def bot() -> Bot:
     """Fixture to create a Bot instance."""
@@ -26,10 +27,12 @@ def bot() -> Bot:
         raise ValueError("BOT_TOKEN environment variable is not set.")
     return Bot(token=token, parse_mode="HTML")
 
+
 @pytest.fixture
 def storage() -> MemoryStorage:
     """Fixture to create a MemoryStorage instance."""
     return MemoryStorage()
+
 
 @pytest.mark.asyncio
 async def test_start_handler_sets_incident_state(bot: Bot, storage: MemoryStorage):
@@ -48,6 +51,7 @@ async def test_start_handler_sets_incident_state(bot: Bot, storage: MemoryStorag
     )
     await start_handler(bot=bot, message=message, state=state)
     assert await state.get_state() == IncidentStates.waiting_object.state
+
 
 def test_get_dispatcher_custom_bot_and_storage(bot: Bot, storage: MemoryStorage):
     """Test that get_dispatcher returns the provided bot and storage objects."""

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,20 +1,26 @@
 from ferum_customs import constants
-from typing import List
+
 
 def test_constants_values() -> None:
     """Test the existence, type, and values of constants in the constants module."""
-    
+
     # List of constants to check
-    constant_names: List[str] = ['STATUS_OTKRYTA', 'STATUS_ZAKRYTA', 'STATUS_V_PROCESE']  # Add all relevant constants here
-    
+    constant_names: list[str] = [
+        "STATUS_OTKRYTA",
+        "STATUS_ZAKRYTA",
+        "STATUS_V_PROCESE",
+    ]  # Add all relevant constants here
+
     # Expected values for the constants
     expected_values = {
-        'STATUS_OTKRYTA': 'expected_value_1',  # Replace with actual expected value
-        'STATUS_ZAKRYTA': 'expected_value_2',   # Replace with actual expected value
-        'STATUS_V_PROCESE': 'expected_value_3',  # Replace with actual expected value
+        "STATUS_OTKRYTA": "expected_value_1",  # Replace with actual expected value
+        "STATUS_ZAKRYTA": "expected_value_2",  # Replace with actual expected value
+        "STATUS_V_PROCESE": "expected_value_3",  # Replace with actual expected value
     }
-    
+
     for name in constant_names:
         assert hasattr(constants, name), f"{name} does not exist in constants"
         assert isinstance(getattr(constants, name), str), f"{name} is not a string"
-        assert getattr(constants, name) == expected_values[name], f"{name} has an unexpected value"
+        assert (
+            getattr(constants, name) == expected_values[name]
+        ), f"{name} has an unexpected value"

--- a/tests/unit/test_file_attachment_utils.py
+++ b/tests/unit/test_file_attachment_utils.py
@@ -1,19 +1,25 @@
 import pytest
+
 from ferum_customs.custom_logic import file_attachment_utils
+
 
 def test_resolve_attachment_public(frappe_stub, tmp_path) -> None:
     """Test resolving a public attachment path."""
     public_files_path = tmp_path / "public" / "files"
     public_files_path.mkdir(parents=True, exist_ok=True)  # Ensure directory exists
-    path, base, name = file_attachment_utils._resolve_attachment_path("/files/test.txt", False)
+    path, base, name = file_attachment_utils._resolve_attachment_path(
+        "/files/test.txt", False
+    )
     assert path == public_files_path / "test.txt"
     assert base == public_files_path
     assert name == "test.txt"
+
 
 def test_resolve_attachment_invalid_prefix(frappe_stub) -> None:
     """Test resolving an attachment path with an invalid prefix raises ValidationError."""
     with pytest.raises(frappe_stub.ValidationError):
         file_attachment_utils._resolve_attachment_path("/bad/test.txt", False)
+
 
 def test_resolve_attachment_traversal(frappe_stub, tmp_path) -> None:
     """Test resolving an attachment path with traversal attempts raises PermissionError."""
@@ -22,11 +28,14 @@ def test_resolve_attachment_traversal(frappe_stub, tmp_path) -> None:
     with pytest.raises(frappe_stub.PermissionError):
         file_attachment_utils._resolve_attachment_path("/files/../secret.txt", False)
 
+
 def test_resolve_attachment_file_not_exist(frappe_stub, tmp_path) -> None:
     """Test resolving a valid attachment path that does not exist."""
     public_files_path = tmp_path / "public" / "files"
     public_files_path.mkdir(parents=True, exist_ok=True)  # Ensure directory exists
-    path, base, name = file_attachment_utils._resolve_attachment_path("/files/nonexistent.txt", False)
+    path, base, name = file_attachment_utils._resolve_attachment_path(
+        "/files/nonexistent.txt", False
+    )
     assert path == public_files_path / "nonexistent.txt"
     assert base == public_files_path
     assert name == "nonexistent.txt"

--- a/tests/unit/test_fsm.py
+++ b/tests/unit/test_fsm.py
@@ -1,8 +1,11 @@
 from telegram_bot.fsm.states import SomeState
 
+
 def test_some_state_attributes() -> None:
     """Test that SomeState has the expected attributes and behaviors."""
     assert hasattr(SomeState, "waiting"), "SomeState should have an attribute 'waiting'"
     # Additional assertions can be added here to verify the behavior of SomeState
-    assert hasattr(SomeState, "some_other_attribute"), "SomeState should have an attribute 'some_other_attribute'"
+    assert hasattr(
+        SomeState, "some_other_attribute"
+    ), "SomeState should have an attribute 'some_other_attribute'"
     # Add more assertions to validate the expected behavior of SomeState

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -1,10 +1,13 @@
-import pytest
 from types import SimpleNamespace
+
+import pytest
+
 from ferum_customs.permissions.permissions import (
     ROLE_CUSTOMER,
     ROLE_ZAKAZCHIK,
     get_service_request_pqc,
 )
+
 
 @pytest.fixture
 def frappe_stub(mocker):
@@ -15,10 +18,14 @@ def frappe_stub(mocker):
     mock.get_cached_doc = mocker.Mock()
     return mock
 
+
 def test_get_service_request_pqc_for_customer(frappe_stub):
     """Test that a customer can retrieve their service request PQC."""
     frappe_stub.session.user = "alice"
-    frappe_stub.has_role.side_effect = lambda role, user=None: role in {ROLE_CUSTOMER, ROLE_ZAKAZCHIK}
+    frappe_stub.has_role.side_effect = lambda role, user=None: role in {
+        ROLE_CUSTOMER,
+        ROLE_ZAKAZCHIK,
+    }
     frappe_stub.get_cached_doc.return_value = SimpleNamespace(
         customer="CUST1",
         get=lambda field, default=None: {"customer": "CUST1"}.get(field, default),
@@ -26,6 +33,7 @@ def test_get_service_request_pqc_for_customer(frappe_stub):
 
     pqc = get_service_request_pqc()
     assert pqc == {"custom_customer": "CUST1"}
+
 
 def test_get_service_request_pqc_for_admin(frappe_stub):
     """Test that an admin cannot retrieve a service request PQC."""

--- a/tests/unit/test_placeholder.py
+++ b/tests/unit/test_placeholder.py
@@ -1,5 +1,6 @@
 # This test validates the functionality of the specific feature in the codebase.
 
+
 def test_feature_functionality():
     # Replace the following with actual logic to test the feature.
     expected_value = 1

--- a/tests/unit/test_portal_menu_roles.py
+++ b/tests/unit/test_portal_menu_roles.py
@@ -1,11 +1,11 @@
 import json
 from pathlib import Path
-from typing import Any, List, Dict
+from typing import Any
 
 FIXTURE_PATH = Path("ferum_customs/fixtures")
 
 
-def load_fixture(name: str) -> List[Dict[str, Any]]:
+def load_fixture(name: str) -> list[dict[str, Any]]:
     file_path = FIXTURE_PATH / name
     if not file_path.exists():
         raise FileNotFoundError(f"Fixture file {name} does not exist.")

--- a/tests/unit/test_service_object_hook.py
+++ b/tests/unit/test_service_object_hook.py
@@ -1,24 +1,21 @@
 import importlib
 from types import SimpleNamespace
-from typing import Dict, Optional
 
 import pytest
 
 
-def throw(msg: str, exc: Optional[Exception] = None) -> None:
-    """Raise a validation error with a message."""
-    raise frappe_stub.ValidationError(msg)
-
-
 def test_validate_duplicate_serial(frappe_stub) -> None:
     """Test validation of duplicate serial numbers in service object."""
-    
+
     # Mock the database check for existing serial numbers
-    def mock_exists(doctype: str, filters: Dict[str, str]) -> bool:
+    def mock_exists(doctype: str, filters: dict[str, str]) -> bool:
         return filters.get("serial_no") == "SN123"
-    
+
     frappe_stub.db.exists = mock_exists
-    captured: Dict[str, str] = {}
+    captured: dict[str, str] = {}
+
+    def throw(msg: str, exc: Exception | None = None) -> None:
+        raise frappe_stub.ValidationError(msg)
 
     frappe_stub.throw = throw
 
@@ -27,9 +24,9 @@ def test_validate_duplicate_serial(frappe_stub) -> None:
     # Create a mock document with a serial number
     doc: SimpleNamespace = SimpleNamespace(serial_no="SN123", name="SO-0001")
     doc.get = lambda k, d=None: getattr(doc, k, d)
-    
+
     with pytest.raises(frappe_stub.ValidationError) as exc_info:
         hooks.validate(doc)
-    
+
     captured["msg"] = str(exc_info.value)
     assert "Серийный номер" in captured["msg"]

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,6 +1,9 @@
 from pathlib import Path
+
 from _pytest.monkeypatch import MonkeyPatch
+
 from ferum_customs.config.settings import Settings
+
 
 def test_settings_env_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Test loading settings from .env file and ignoring extra variables.
@@ -9,15 +12,17 @@ def test_settings_env_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     environment variables from a .env file and ignores any
     extra variables that are not defined in the Settings class.
     """
-    env_content = (
-        "TELEGRAM_BOT_TOKEN=token123\nSITE_NAME=mysite\nEXTRA_VAR=ignored"
-    )
+    env_content = "TELEGRAM_BOT_TOKEN=token123\nSITE_NAME=mysite\nEXTRA_VAR=ignored"
     tmp_env = tmp_path / ".env"
     tmp_env.write_text(env_content)
     monkeypatch.chdir(tmp_path)
 
-    settings: Settings = Settings(_env_file=tmp_env)  # Assuming Settings can load from a file
-    assert settings.telegram_bot_token == "token123", "Expected TELEGRAM_BOT_TOKEN to be 'token123'"
+    settings: Settings = Settings(
+        _env_file=tmp_env
+    )  # Assuming Settings can load from a file
+    assert (
+        settings.telegram_bot_token == "token123"
+    ), "Expected TELEGRAM_BOT_TOKEN to be 'token123'"
     assert settings.site_name == "mysite", "Expected SITE_NAME to be 'mysite'"
     assert not hasattr(settings, "EXTRA_VAR"), "Expected EXTRA_VAR to be ignored"
 
@@ -26,7 +31,9 @@ def test_settings_env_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     env_content_missing = "SITE_NAME=mysite"
     tmp_env.write_text(env_content_missing)
     settings = Settings(_env_file=tmp_env)
-    assert settings.telegram_bot_token is None, "Expected TELEGRAM_BOT_TOKEN to be None when not set"
+    assert (
+        settings.telegram_bot_token is None
+    ), "Expected TELEGRAM_BOT_TOKEN to be None when not set"
 
     # Test for invalid values (if applicable)
     # Add more tests as necessary


### PR DESCRIPTION
## Summary
- replace deprecated typing aliases with built-in generics
- clean up permission type unions and test helpers

## Testing
- `ruff check ferum_customs tests scripts telegram_bot`
- `cd ui-tests && npm run lint`
- `mypy ferum_customs tests scripts telegram_bot` *(fails: Class cannot subclass "Document"...)*

------
https://chatgpt.com/codex/tasks/task_e_689090b4b420832892671be2274fbe1a