### PR TITLE
feat: add frontend docker service

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -23,10 +23,11 @@
 
 * [ ] Установить Frappe/ERPNext с PostgreSQL и Redis.
 * [ ] Настроить Nginx как reverse proxy с HTTPS (TLS).
-* [ ] Создать отдельные Docker-сборки для:
+* [x] Создать отдельные Docker-сборки для:
 
-  * кастомного backend (FastAPI/NestJS),
-  * frontend (React).
+  * кастомного backend (FastAPI/NestJS) ✅
+  * frontend (React) ✅
+
 
 ---
 

--- a/ai_tasks.json
+++ b/ai_tasks.json
@@ -172,7 +172,7 @@
       "name": "Инфраструктура (Docker + CI/CD)",
       "tasks": [
         { "id": "0.1", "description": "Поднять ERPNext v14 (PostgreSQL + Redis) и Nginx + TLS.", "dependencies": [], "status": "done" },
-        { "id": "0.2", "description": "Создать Docker-контейнеры backend (FastAPI/NestJS) и frontend (React).", "dependencies": ["0.1"], "status": "pending" },
+        { "id": "0.2", "description": "Создать Docker-контейнеры backend (FastAPI/NestJS) и frontend (React).", "dependencies": ["0.1"], "status": "done" },
         { "id": "0.3", "description": "Настроить GitHub Actions из ci_template_github_actions.", "dependencies": ["0.2"], "status": "pending" }
       ]
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,28 @@ services:
       - ./docker/entrypoint.sh:/usr/local/bin/docker-entrypoint.sh:ro
     command: ["/usr/local/bin/docker-entrypoint.sh", "bench", "start"]
 
+  fastapi:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.fastapi
+    depends_on:
+      frappe:
+        condition: service_started
+    ports:
+      - "8100:8000"
+    env_file:
+      - .env
+
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.frontend
+    depends_on:
+      fastapi:
+        condition: service_started
+    ports:
+      - "3000:3000"
+
   nginx:
     image: nginx:alpine
     depends_on:

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+
+WORKDIR /app
+COPY ../frontend ./
+RUN npm install -g serve
+EXPOSE 3000
+CMD ["serve", "-s", ".", "-l", "3000"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,3 +21,12 @@ services:
       - "8100:8000"
     env_file:
       - .env
+
+  frontend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.frontend
+    depends_on:
+      - fastapi
+    ports:
+      - "3000:3000"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Ferum Customs Frontend</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      function App() {
+        return <h1>Ferum Customs Frontend</h1>;
+      }
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(<App />);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add node-based Dockerfile for a minimal React frontend
- wire frontend service into docker-compose setup
- mark infrastructure task for frontend/backend containers as complete

## Testing
- `pre-commit run --files ai_tasks.json docker/Dockerfile.frontend docker/docker-compose.yml docker-compose.yml frontend/index.html agent.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe'; pydantic.errors.PydanticImportError: `BaseSettings` moved to pydantic-settings)*

------
https://chatgpt.com/codex/tasks/task_e_6891ea28fb8c8328a3951d66880fb960