### PR TITLE
chore: expand gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ jspm_packages/
 frappe_docker/
 
 *.log
+*.tmp
+*.bak
 *.pot
 *.mo
 .DS_Store
@@ -74,3 +76,15 @@ frappe_docker/
 .pytest_cache/
 .ruff_cache/
 .codex/config.toml
+
+# Coverage reports
+htmlcov/
+coverage.xml
+
+# Local environments
+testvenv/
+frappe-bench/
+
+# Playwright test artifacts
+ui-tests/playwright-report/
+ui-tests/test-results/


### PR DESCRIPTION
## Summary
- ignore tmp and backup files
- ignore coverage artifacts, local benches and test venv
- ignore Playwright test outputs

## Testing
- `pre-commit run --files .gitignore`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6892442372fc8328899b183fd5108c9a